### PR TITLE
Adjacency matrix interpretation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Gguess = np.array([
     [0, 0, 0, 0, 0]
 ], dtype=np.int8)
 
-print(ancestor_aid(Gtrue, Gguess))
+print(ancestor_aid(Gtrue, Gguess, edge_direction="from row to column"))
 print(shd(Gtrue, Gguess))
 ```
 
@@ -98,14 +98,16 @@ structural intervention distance for directed acyclic graphs as a special case. 
 
 ## Implemented Distances
 
-* `ancestor_aid(Gtrue, Gguess)`
-* `oset_aid(Gtrue, Gguess)`
-* `parent_aid(Gtrue, Gguess)`
+* `ancestor_aid(Gtrue, Gguess, edge_direction)`
+* `oset_aid(Gtrue, Gguess, edge_direction)`
+* `parent_aid(Gtrue, Gguess, edge_direction)`
 * for convenience, the following distances are implemented, too
     * `shd(Gtrue, Gguess)`
-    * `sid(Gtrue, Gguess)` – only for DAGs!
+    * `sid(Gtrue, Gguess, edge_direction)` – only for DAGs!
 
-where Gtrue and Gguess are adjacency matrices of a DAG or CPDAG.
+where `Gtrue` and `Gguess` are adjacency matrices of a DAG or CPDAG
+and `edge_direction` determines whether a `1` at r-th row and c-th column of an adjacency matrix
+codes the edge `r → c` (`edge_direction="from row to column"`) or `c → r` (`edge_direction="from column to row"`).
 The functions are not symmetric in their input:
 To calculate a distance,
 identifying formulas for causal effects are inferred in the graph `Gguess`
@@ -118,14 +120,18 @@ and we define normalisation as  `normalised_distance = mistake_count / p(p-1)`.
 
 All graphs are assumed simple, that is, at most one edge is allowed between any two nodes.
 An adjacency matrix for a DAG may only contain 0s and 1s;
-a `1` in row `s` and column `t` codes a directed edge `Xₛ → Xₜ`;
+if `edge_direction="from row to column"`, then
+a `1` in row `r` and column `c` codes a directed edge `r → c`;
+if `edge_direction="from column to row"`, then
+a `1` in row `r` and column `c` codes a directed edge `c → r`;
 DAG inputs are validated for acyclicity.
 An adjacency matrix for a CPDAG may only contain 0s, 1s and 2s;
-a `2` in row `s` and column `t` codes a undirected edge `Xₛ — Xₜ`
-(an additional `2` in row `t` and column `s` is ignored; only one of the two entries is required to code an undirected edge);
+for either setting of `edge_direction`,
+a `2` in row `r` and column `c` codes an undirected edge `r — c`
+(an additional `2` in row `c` and column `r` is ignored; only one of the two entries is required to code an undirected edge);
 CPDAG inputs are not validated and __the user needs to ensure the adjacency matrix indeed codes a valid CPDAG (instead of just a PDAG)__.
-You may also calculate the SID between DAGs via `parent_aid(DAGtrue, DAGguess)`,
-but we recommend `ancestor_aid` and `oset_aid` and for CPDAG inputs our `parent_aid` does not coincide with the SID
+You may also calculate the SID between DAGs via `parent_aid(DAGtrue, DAGguess, edge_direction)`,
+but we recommend `ancestor_aid` and `oset_aid` and for CPDAG inputs the `parent_aid` does not coincide with the SID
 (see also our accompanying article).
 
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ structural intervention distance for directed acyclic graphs as a special case. 
 where `Gtrue` and `Gguess` are adjacency matrices of a DAG or CPDAG
 and `edge_direction` determines whether a `1` at r-th row and c-th column of an adjacency matrix
 codes the edge `r → c` (`edge_direction="from row to column"`) or `c → r` (`edge_direction="from column to row"`).
-The functions are not symmetric in their input:
+The functions are not symmetric in their inputs:
 To calculate a distance,
 identifying formulas for causal effects are inferred in the graph `Gguess`
 and verified against the graph `Gtrue`.
@@ -127,14 +127,14 @@ a `1` in row `r` and column `c` codes a directed edge `r → c`;
 if `edge_direction="from column to row"`, then
 a `1` in row `r` and column `c` codes a directed edge `c → r`;
 for either setting of `edge_direction`,
-a `2` in row `r` and column `c` codes an undirected edge `r – t`
+a `2` in row `r` and column `c` codes an undirected edge `r – c`
 (an additional `2` in row `c` and column `r` is ignored;
 one of the two entries is sufficient to code an undirected edge).
 
 An adjacency matrix for a DAG may only contain 0s and 1s.
 An adjacency matrix for a CPDAG may only contain 0s, 1s and 2s.
-DAG and CPDAG inputs are validated for acyclicity. 
-However, for CPDAG inputs, __the user needs to ensure the adjacency 
+DAG and CPDAG inputs are validated for acyclicity.
+However, for CPDAG inputs, __the user needs to ensure the adjacency
 matrix indeed codes a valid CPDAG (instead of just a PDAG)__.
 
 
@@ -145,7 +145,7 @@ Here, for a graph with $p$ nodes,
 sparse graphs have $10p$ edges in expectation,
 dense graphs have $0.3p(p-1)/2$ edges in expectation,
 and
-sparse graphs have $0.75p$ edges in expectation.
+x-sparse graphs have $0.75p$ edges in expectation.
 
 __Maximum graph size feasible within 1 minute__
 

--- a/README.md
+++ b/README.md
@@ -118,21 +118,24 @@ and the number of wrongly inferred causal effects, `mistake_count`.
 There are $p(p-1)$ pairwise causal effects to infer in graphs with $p$ nodes
 and we define normalisation as  `normalised_distance = mistake_count / p(p-1)`.
 
-All graphs are assumed simple, that is, at most one edge is allowed between any two nodes.
-An adjacency matrix for a DAG may only contain 0s and 1s;
-if `edge_direction="from row to column"`, then
-a `1` in row `r` and column `c` codes a directed edge `r → c`;
-if `edge_direction="from column to row"`, then
-a `1` in row `r` and column `c` codes a directed edge `c → r`;
-DAG inputs are validated for acyclicity.
-An adjacency matrix for a CPDAG may only contain 0s, 1s and 2s;
-for either setting of `edge_direction`,
-a `2` in row `r` and column `c` codes an undirected edge `r — c`
-(an additional `2` in row `c` and column `r` is ignored; only one of the two entries is required to code an undirected edge);
-CPDAG inputs are not validated and __the user needs to ensure the adjacency matrix indeed codes a valid CPDAG (instead of just a PDAG)__.
 You may also calculate the SID between DAGs via `parent_aid(DAGtrue, DAGguess, edge_direction)`,
 but we recommend `ancestor_aid` and `oset_aid` and for CPDAG inputs the `parent_aid` does not coincide with the SID
 (see also our accompanying article).
+
+If `edge_direction="from row to column"`, then
+a `1` in row `r` and column `c` codes a directed edge `r → c`;
+if `edge_direction="from column to row"`, then
+a `1` in row `r` and column `c` codes a directed edge `c → r`;
+for either setting of `edge_direction`,
+a `2` in row `r` and column `c` codes an undirected edge `r – t`
+(an additional `2` in row `c` and column `r` is ignored;
+one of the two entries is sufficient to code an undirected edge).
+
+An adjacency matrix for a DAG may only contain 0s and 1s.
+An adjacency matrix for a CPDAG may only contain 0s, 1s and 2s.
+DAG and CPDAG inputs are validated for acyclicity. 
+However, for CPDAG inputs, __the user needs to ensure the adjacency 
+matrix indeed codes a valid CPDAG (instead of just a PDAG)__.
 
 
 ## Empirical Runtime Analysis

--- a/gadjid/Cargo.lock
+++ b/gadjid/Cargo.lock
@@ -82,16 +82,15 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.36.1"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7c22c4d34ef4788c351e971c52bfdfe7ea2766f8c5466bc175dd46e52ac22e"
+checksum = "1718b3f2b85bb5054baf8ce406e36401f27c3169205f4175504c4b1d98252d3f"
 dependencies = [
  "console",
  "lazy_static",
  "linked-hash-map",
  "serde",
  "similar",
- "yaml-rust",
 ]
 
 [[package]]
@@ -306,12 +305,3 @@ name = "windows_x86_64_msvc"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
-]

--- a/gadjid/Cargo.lock
+++ b/gadjid/Cargo.lock
@@ -59,7 +59,7 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "gadjid"
-version = "0.1.0-a.0"
+version = "0.1.0-a.1"
 dependencies = [
  "insta",
  "rand",
@@ -168,9 +168,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
@@ -220,9 +220,9 @@ checksum = "32fea41aca09ee824cc9724996433064c89f7777e60762749a4170a14abbfa21"
 
 [[package]]
 name = "syn"
-version = "2.0.53"
+version = "2.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
+checksum = "002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/gadjid/Cargo.toml
+++ b/gadjid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gadjid"
-version = "0.1.0-a.0"
+version = "0.1.0-a.1"
 edition = "2021"
 license = "MPL-2.0"
 authors = ["Theo Würtzen", "Sebastian Weichwald", "Leonard Henckel"]

--- a/gadjid/src/graph_loading/edgelist.rs
+++ b/gadjid/src/graph_loading/edgelist.rs
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 //! This module contains the Edgelist struct, which is an iterator over the edges of a graph.
 
-/// An iterator over the edges of a graph, yielding `(from/to, to/from, edgetype)` tuples.
-/// The choice between `from/to` is indicated by the associated implementation of `Order` ([`IterationLayoutTag`]).
-/// Will skip over all 0's in the inner iterator, yielding only nonzero checks.
+/// An iterator over the edges of a graph, yielding `(from, to, edgetype)` tuples.
+
+/// Example yield: `(4, 7, 1)`, which is to be interpreted as `4 -> 7`.
+
+/// Will skip over all 0's in the inner iterator, yielding only nonzero entries.
 /// Will panic during load if the inner iterator yields edges in a non-row-by-row or non-column-by-column order.
 pub struct Edgelist<Order: IterationLayoutTag, I>
 where
@@ -76,15 +78,12 @@ where
 /// associated with this trait, it is purely for strong type checking.
 pub trait IterationLayoutTag: Sized {}
 
-/// Implementation of [`IterationLayoutTag`] for row-major order. Fed as type parameter when
-/// constructing [`Edgelist`]. This indicates that the edgelist returns edges in a row-major order.
 /// This indicates that the outermost index is the row, and the innermost index is the column. The
-/// column index will vary the fastest. The iterator will yield triples of `(row, column, value)`.
+/// column index will vary the fastest. The iterator will yield triples of `(row, column, edge_type)`.
 pub struct RowMajorOrder;
-/// Implementation of [`IterationLayoutTag`] for column-major order. Fed as type parameter when
-/// constructing [`Edgelist`]. This indicates that the edgelist returns edges in a column-major order.
+
 /// This indicates that the outermost index is the column, and the innermost index is the row. The
-/// row index will vary the fastest. The iterator will yield triples of `(column, row, value)`.
+/// row index will vary the fastest. The iterator will yield triples of `(column, row, edge_type)`.
 pub struct ColumnMajorOrder;
 
 // There is no actual functionality associated with the trait implementation, it is purely for strong type checking.

--- a/gadjid/src/graph_loading/edgelist.rs
+++ b/gadjid/src/graph_loading/edgelist.rs
@@ -78,11 +78,11 @@ where
 /// associated with this trait, it is purely for strong type checking.
 pub trait IterationLayoutTag: Sized {}
 
-/// This indicates that the outermost index is the row, and the innermost index is the column. The
+/// This indicates that the outer index is the row, and the inner index is the column. The
 /// column index will vary the fastest. The iterator will yield triples of `(row, column, edge_type)`.
 pub struct RowMajorOrder;
 
-/// This indicates that the outermost index is the column, and the innermost index is the row. The
+/// This indicates that the outer index is the column, and the inner index is the row. The
 /// row index will vary the fastest. The iterator will yield triples of `(column, row, edge_type)`.
 pub struct ColumnMajorOrder;
 

--- a/gadjid/src/graph_operations/oset_aid.rs
+++ b/gadjid/src/graph_operations/oset_aid.rs
@@ -162,7 +162,7 @@ mod test {
             vec![0, 0, 0, 1, 0, 0, 0, 0],
         ];
 
-        let dag = PDAG::from_vecvec(v_dag);
+        let dag = PDAG::from_row_to_col_vecvec(v_dag);
 
         assert_eq!(
             FxHashSet::from_iter([7]),
@@ -214,7 +214,7 @@ mod test {
             vec![0, 0, 0, 1, 0, 0, 0, 0],
         ];
 
-        let dag = PDAG::from_vecvec(v_dag);
+        let dag = PDAG::from_row_to_col_vecvec(v_dag);
 
         assert_eq!(
             FxHashSet::from_iter([5]),

--- a/gadjid/src/graph_operations/oset_aid.rs
+++ b/gadjid/src/graph_operations/oset_aid.rs
@@ -162,7 +162,7 @@ mod test {
             vec![0, 0, 0, 1, 0, 0, 0, 0],
         ];
 
-        let dag = PDAG::from_row_to_col_vecvec(v_dag);
+        let dag = PDAG::from_row_to_column_vecvec(v_dag);
 
         assert_eq!(
             FxHashSet::from_iter([7]),
@@ -214,7 +214,7 @@ mod test {
             vec![0, 0, 0, 1, 0, 0, 0, 0],
         ];
 
-        let dag = PDAG::from_row_to_col_vecvec(v_dag);
+        let dag = PDAG::from_row_to_column_vecvec(v_dag);
 
         assert_eq!(
             FxHashSet::from_iter([5]),

--- a/gadjid/src/graph_operations/parent_aid.rs
+++ b/gadjid/src/graph_operations/parent_aid.rs
@@ -148,9 +148,9 @@ mod test {
             vec![0, 0, 0, 0, 0],
             vec![0, 0, 0, 0, 0],
         ];
-        let g_dag = PDAG::from_row_to_col_vecvec(g);
-        let h1_dag = PDAG::from_row_to_col_vecvec(h1);
-        let h2_dag = PDAG::from_row_to_col_vecvec(h2);
+        let g_dag = PDAG::from_row_to_column_vecvec(g);
+        let h1_dag = PDAG::from_row_to_column_vecvec(h1);
+        let h2_dag = PDAG::from_row_to_column_vecvec(h2);
 
         assert_eq!(parent_aid(&g_dag, &h1_dag), (0.0, 0));
         assert_eq!(parent_aid(&g_dag, &h2_dag), (0.4, 8));

--- a/gadjid/src/graph_operations/parent_aid.rs
+++ b/gadjid/src/graph_operations/parent_aid.rs
@@ -148,9 +148,9 @@ mod test {
             vec![0, 0, 0, 0, 0],
             vec![0, 0, 0, 0, 0],
         ];
-        let g_dag = PDAG::from_vecvec(g);
-        let h1_dag = PDAG::from_vecvec(h1);
-        let h2_dag = PDAG::from_vecvec(h2);
+        let g_dag = PDAG::from_row_to_col_vecvec(g);
+        let h1_dag = PDAG::from_row_to_col_vecvec(h1);
+        let h2_dag = PDAG::from_row_to_col_vecvec(h2);
 
         assert_eq!(parent_aid(&g_dag, &h1_dag), (0.0, 0));
         assert_eq!(parent_aid(&g_dag, &h2_dag), (0.4, 8));

--- a/gadjid/src/graph_operations/possible_descendants.rs
+++ b/gadjid/src/graph_operations/possible_descendants.rs
@@ -34,7 +34,7 @@ pub(crate) fn get_possible_descendants<'a>(
 mod test {
     use rustc_hash::FxHashSet;
 
-    use crate::{graph_operations::possible_descendants, PDAG};
+    use crate::PDAG;
 
     #[test]
     pub fn test_possible_descendants() {

--- a/gadjid/src/graph_operations/possible_descendants.rs
+++ b/gadjid/src/graph_operations/possible_descendants.rs
@@ -47,7 +47,7 @@ mod test {
             vec![0, 0, 0, 0],
             vec![0, 0, 0, 0],
         ];
-        let cpdag = PDAG::from_row_to_col_vecvec(cpdag);
+        let cpdag = PDAG::from_row_to_column_vecvec(cpdag);
         let result = super::get_possible_descendants(&cpdag, [0].iter());
         assert_eq!(result, FxHashSet::from_iter(vec![0, 1, 2, 3]));
 
@@ -62,7 +62,7 @@ mod test {
             vec![0, 0, 0, 0, 0, 0],
             vec![0, 0, 0, 0, 1, 0],
         ];
-        let cpdag = PDAG::from_row_to_col_vecvec(cpdag);
+        let cpdag = PDAG::from_row_to_column_vecvec(cpdag);
         let result = super::get_possible_descendants(&cpdag, [4].iter());
         assert_eq!(result, FxHashSet::from_iter(vec![0, 1, 2, 3, 4]));
     }

--- a/gadjid/src/graph_operations/possible_descendants.rs
+++ b/gadjid/src/graph_operations/possible_descendants.rs
@@ -34,7 +34,7 @@ pub(crate) fn get_possible_descendants<'a>(
 mod test {
     use rustc_hash::FxHashSet;
 
-    use crate::PDAG;
+    use crate::{graph_operations::possible_descendants, PDAG};
 
     #[test]
     pub fn test_possible_descendants() {
@@ -47,7 +47,7 @@ mod test {
             vec![0, 0, 0, 0],
             vec![0, 0, 0, 0],
         ];
-        let cpdag = PDAG::from_vecvec(cpdag);
+        let cpdag = PDAG::from_row_to_col_vecvec(cpdag);
         let result = super::get_possible_descendants(&cpdag, [0].iter());
         assert_eq!(result, FxHashSet::from_iter(vec![0, 1, 2, 3]));
 
@@ -62,7 +62,7 @@ mod test {
             vec![0, 0, 0, 0, 0, 0],
             vec![0, 0, 0, 0, 1, 0],
         ];
-        let cpdag = PDAG::from_vecvec(cpdag);
+        let cpdag = PDAG::from_row_to_col_vecvec(cpdag);
         let result = super::get_possible_descendants(&cpdag, [4].iter());
         assert_eq!(result, FxHashSet::from_iter(vec![0, 1, 2, 3, 4]));
     }

--- a/gadjid/src/graph_operations/reachability.rs
+++ b/gadjid/src/graph_operations/reachability.rs
@@ -643,7 +643,7 @@ mod test {
             vec![0, 0, 0, 0],
             vec![0, 0, 0, 0],
         ];
-        let cpdag = PDAG::from_row_to_col_vecvec(cpdag);
+        let cpdag = PDAG::from_row_to_column_vecvec(cpdag);
 
         assert!(get_nam(&cpdag, &[0]) == FxHashSet::from_iter([3]));
     }
@@ -660,8 +660,8 @@ mod test {
             vec![0, 2], //
             vec![0, 0],
         ];
-        let dag = PDAG::from_row_to_col_vecvec(dag);
-        let cpdag = PDAG::from_row_to_col_vecvec(cpdag);
+        let dag = PDAG::from_row_to_column_vecvec(dag);
+        let cpdag = PDAG::from_row_to_column_vecvec(cpdag);
 
         assert_eq!((1.0, 2), parent_aid(&dag, &cpdag));
         assert_eq!((1.0, 2), parent_aid(&cpdag, &dag));

--- a/gadjid/src/graph_operations/reachability.rs
+++ b/gadjid/src/graph_operations/reachability.rs
@@ -643,7 +643,7 @@ mod test {
             vec![0, 0, 0, 0],
             vec![0, 0, 0, 0],
         ];
-        let cpdag = PDAG::from_vecvec(cpdag);
+        let cpdag = PDAG::from_row_to_col_vecvec(cpdag);
 
         assert!(get_nam(&cpdag, &[0]) == FxHashSet::from_iter([3]));
     }
@@ -660,8 +660,8 @@ mod test {
             vec![0, 2], //
             vec![0, 0],
         ];
-        let dag = PDAG::from_vecvec(dag);
-        let cpdag = PDAG::from_vecvec(cpdag);
+        let dag = PDAG::from_row_to_col_vecvec(dag);
+        let cpdag = PDAG::from_row_to_col_vecvec(cpdag);
 
         assert_eq!((1.0, 2), parent_aid(&dag, &cpdag));
         assert_eq!((1.0, 2), parent_aid(&cpdag, &dag));

--- a/gadjid/src/graph_operations/ruletables/ancestors.rs
+++ b/gadjid/src/graph_operations/ruletables/ancestors.rs
@@ -48,7 +48,7 @@ mod test {
             vec![0, 0, 0],
         ];
 
-        let dag = PDAG::from_row_to_col_vecvec(v_dag);
+        let dag = PDAG::from_row_to_column_vecvec(v_dag);
 
         let expected = HashSet::from([0, 1, 2]);
         let result = get_ancestors(&dag, [1, 2].iter());
@@ -78,7 +78,7 @@ mod test {
             vec![0, 0, 1, 1, 0],
         ];
 
-        let dag = PDAG::from_row_to_col_vecvec(v_dag);
+        let dag = PDAG::from_row_to_column_vecvec(v_dag);
 
         let expected = HashSet::from([0, 1, 2, 4]);
         let result = get_ancestors(&dag, [2].iter());

--- a/gadjid/src/graph_operations/ruletables/ancestors.rs
+++ b/gadjid/src/graph_operations/ruletables/ancestors.rs
@@ -48,7 +48,7 @@ mod test {
             vec![0, 0, 0],
         ];
 
-        let dag = PDAG::from_vecvec(v_dag);
+        let dag = PDAG::from_row_to_col_vecvec(v_dag);
 
         let expected = HashSet::from([0, 1, 2]);
         let result = get_ancestors(&dag, [1, 2].iter());
@@ -78,7 +78,7 @@ mod test {
             vec![0, 0, 1, 1, 0],
         ];
 
-        let dag = PDAG::from_vecvec(v_dag);
+        let dag = PDAG::from_row_to_col_vecvec(v_dag);
 
         let expected = HashSet::from([0, 1, 2, 4]);
         let result = get_ancestors(&dag, [2].iter());

--- a/gadjid/src/graph_operations/ruletables/children.rs
+++ b/gadjid/src/graph_operations/ruletables/children.rs
@@ -38,7 +38,7 @@ mod test {
             vec![0, 0, 0],
         ];
 
-        let dag = PDAG::from_vecvec(v_dag);
+        let dag = PDAG::from_row_to_col_vecvec(v_dag);
 
         let result = get_children(&dag, [0].iter());
         let expected = HashSet::from([1]);
@@ -68,7 +68,7 @@ mod test {
             vec![0, 0, 1, 1, 0],
         ];
 
-        let dag = PDAG::from_vecvec(v_dag);
+        let dag = PDAG::from_row_to_col_vecvec(v_dag);
 
         let result = get_children(&dag, [4].iter());
         let expected = HashSet::from([2, 3]);

--- a/gadjid/src/graph_operations/ruletables/children.rs
+++ b/gadjid/src/graph_operations/ruletables/children.rs
@@ -38,7 +38,7 @@ mod test {
             vec![0, 0, 0],
         ];
 
-        let dag = PDAG::from_row_to_col_vecvec(v_dag);
+        let dag = PDAG::from_row_to_column_vecvec(v_dag);
 
         let result = get_children(&dag, [0].iter());
         let expected = HashSet::from([1]);
@@ -68,7 +68,7 @@ mod test {
             vec![0, 0, 1, 1, 0],
         ];
 
-        let dag = PDAG::from_row_to_col_vecvec(v_dag);
+        let dag = PDAG::from_row_to_column_vecvec(v_dag);
 
         let result = get_children(&dag, [4].iter());
         let expected = HashSet::from([2, 3]);

--- a/gadjid/src/graph_operations/ruletables/descendants.rs
+++ b/gadjid/src/graph_operations/ruletables/descendants.rs
@@ -48,7 +48,7 @@ mod test {
             vec![0, 0, 0],
         ];
 
-        let dag = PDAG::from_row_to_col_vecvec(v_dag);
+        let dag = PDAG::from_row_to_column_vecvec(v_dag);
 
         let expected = HashSet::from([1, 2]);
         let result = get_descendants(&dag, [2, 1].iter());
@@ -78,7 +78,7 @@ mod test {
             vec![0, 0, 1, 1, 0],
         ];
 
-        let dag = PDAG::from_row_to_col_vecvec(v_dag);
+        let dag = PDAG::from_row_to_column_vecvec(v_dag);
 
         let expected = HashSet::from([2, 3]);
         let result = get_descendants(&dag, [2].iter());

--- a/gadjid/src/graph_operations/ruletables/descendants.rs
+++ b/gadjid/src/graph_operations/ruletables/descendants.rs
@@ -48,7 +48,7 @@ mod test {
             vec![0, 0, 0],
         ];
 
-        let dag = PDAG::from_vecvec(v_dag);
+        let dag = PDAG::from_row_to_col_vecvec(v_dag);
 
         let expected = HashSet::from([1, 2]);
         let result = get_descendants(&dag, [2, 1].iter());
@@ -78,7 +78,7 @@ mod test {
             vec![0, 0, 1, 1, 0],
         ];
 
-        let dag = PDAG::from_vecvec(v_dag);
+        let dag = PDAG::from_row_to_col_vecvec(v_dag);
 
         let expected = HashSet::from([2, 3]);
         let result = get_descendants(&dag, [2].iter());

--- a/gadjid/src/graph_operations/ruletables/parents.rs
+++ b/gadjid/src/graph_operations/ruletables/parents.rs
@@ -37,7 +37,7 @@ mod test {
             vec![0, 0, 0],
         ];
 
-        let dag = PDAG::from_row_to_col_vecvec(v_dag);
+        let dag = PDAG::from_row_to_column_vecvec(v_dag);
 
         let result = get_parents(&dag, [0].iter());
         let expected = HashSet::from([]);
@@ -67,7 +67,7 @@ mod test {
             vec![0, 0, 1, 1, 0],
         ];
 
-        let dag = PDAG::from_row_to_col_vecvec(v_dag);
+        let dag = PDAG::from_row_to_column_vecvec(v_dag);
 
         let result = get_parents(&dag, [4].iter());
         let expected = HashSet::from([]);

--- a/gadjid/src/graph_operations/ruletables/parents.rs
+++ b/gadjid/src/graph_operations/ruletables/parents.rs
@@ -37,7 +37,7 @@ mod test {
             vec![0, 0, 0],
         ];
 
-        let dag = PDAG::from_vecvec(v_dag);
+        let dag = PDAG::from_row_to_col_vecvec(v_dag);
 
         let result = get_parents(&dag, [0].iter());
         let expected = HashSet::from([]);
@@ -67,7 +67,7 @@ mod test {
             vec![0, 0, 1, 1, 0],
         ];
 
-        let dag = PDAG::from_vecvec(v_dag);
+        let dag = PDAG::from_row_to_col_vecvec(v_dag);
 
         let result = get_parents(&dag, [4].iter());
         let expected = HashSet::from([]);

--- a/gadjid/src/graph_operations/ruletables/proper_ancestors.rs
+++ b/gadjid/src/graph_operations/ruletables/proper_ancestors.rs
@@ -60,7 +60,7 @@ mod test {
             vec![0, 0, 0],
         ];
 
-        let dag = PDAG::from_vecvec(v_dag);
+        let dag = PDAG::from_row_to_col_vecvec(v_dag);
 
         let result = get_proper_ancestors(&dag, [].iter(), [2].iter());
         let expected = HashSet::from([0, 1, 2]);
@@ -82,7 +82,7 @@ mod test {
             vec![0, 0, 0, 0],
         ];
 
-        let dag = PDAG::from_vecvec(v_dag);
+        let dag = PDAG::from_row_to_col_vecvec(v_dag);
 
         let result = get_proper_ancestors(&dag, [].iter(), [3].iter());
         let expected = HashSet::from([0, 1, 2, 3]);
@@ -100,7 +100,7 @@ mod test {
             vec![0, 0, 0, 0, 1],
             vec![0, 0, 0, 0, 0],
         ];
-        let dag = PDAG::from_vecvec(v_dag);
+        let dag = PDAG::from_row_to_col_vecvec(v_dag);
 
         let result = get_proper_ancestors(&dag, [].iter(), [4].iter());
         let expected = HashSet::from([0, 1, 2, 3, 4]);

--- a/gadjid/src/graph_operations/ruletables/proper_ancestors.rs
+++ b/gadjid/src/graph_operations/ruletables/proper_ancestors.rs
@@ -60,7 +60,7 @@ mod test {
             vec![0, 0, 0],
         ];
 
-        let dag = PDAG::from_row_to_col_vecvec(v_dag);
+        let dag = PDAG::from_row_to_column_vecvec(v_dag);
 
         let result = get_proper_ancestors(&dag, [].iter(), [2].iter());
         let expected = HashSet::from([0, 1, 2]);
@@ -82,7 +82,7 @@ mod test {
             vec![0, 0, 0, 0],
         ];
 
-        let dag = PDAG::from_row_to_col_vecvec(v_dag);
+        let dag = PDAG::from_row_to_column_vecvec(v_dag);
 
         let result = get_proper_ancestors(&dag, [].iter(), [3].iter());
         let expected = HashSet::from([0, 1, 2, 3]);
@@ -100,7 +100,7 @@ mod test {
             vec![0, 0, 0, 0, 1],
             vec![0, 0, 0, 0, 0],
         ];
-        let dag = PDAG::from_row_to_col_vecvec(v_dag);
+        let dag = PDAG::from_row_to_column_vecvec(v_dag);
 
         let result = get_proper_ancestors(&dag, [].iter(), [4].iter());
         let expected = HashSet::from([0, 1, 2, 3, 4]);

--- a/gadjid/src/graph_operations/shd.rs
+++ b/gadjid/src/graph_operations/shd.rs
@@ -149,7 +149,10 @@ mod test {
         let g_guess = vec![vec![0]];
 
         assert_eq!(shd_from_adjacency(&g_truth, &g_guess), (0f64, 0));
-        let (d_truth, d_guess) = (PDAG::from_row_to_col_vecvec(g_truth), PDAG::from_row_to_col_vecvec(g_guess));
+        let (d_truth, d_guess) = (
+            PDAG::from_row_to_col_vecvec(g_truth),
+            PDAG::from_row_to_col_vecvec(g_guess),
+        );
 
         assert_eq!(shd(&d_truth, &d_guess), (0f64, 0));
 
@@ -162,7 +165,10 @@ mod test {
             vec![0, 0],
         ];
         assert_eq!(shd_from_adjacency(&g_truth, &g_guess), (1f64, 1));
-        let (d_truth, d_guess) = (PDAG::from_row_to_col_vecvec(g_truth), PDAG::from_row_to_col_vecvec(g_guess));
+        let (d_truth, d_guess) = (
+            PDAG::from_row_to_col_vecvec(g_truth),
+            PDAG::from_row_to_col_vecvec(g_guess),
+        );
         assert_eq!(shd(&d_truth, &d_guess), (1f64, 1));
 
         // 0 -> 1
@@ -177,7 +183,10 @@ mod test {
         ];
 
         assert_eq!(shd_from_adjacency(&g_truth, &g_guess), (1f64, 1));
-        let (d_truth, d_guess) = (PDAG::from_row_to_col_vecvec(g_truth), PDAG::from_row_to_col_vecvec(g_guess));
+        let (d_truth, d_guess) = (
+            PDAG::from_row_to_col_vecvec(g_truth),
+            PDAG::from_row_to_col_vecvec(g_guess),
+        );
 
         assert_eq!(shd(&d_truth, &d_guess), (1f64, 1));
 
@@ -192,7 +201,10 @@ mod test {
             vec![0, 0, 0],
         ];
         assert_eq!(shd_from_adjacency(&g_truth, &g_guess), (0f64, 0));
-        let (d_truth, d_guess) = (PDAG::from_row_to_col_vecvec(g_truth), PDAG::from_row_to_col_vecvec(g_guess));
+        let (d_truth, d_guess) = (
+            PDAG::from_row_to_col_vecvec(g_truth),
+            PDAG::from_row_to_col_vecvec(g_guess),
+        );
 
         assert_eq!(shd(&d_truth, &d_guess), (0f64, 0));
 
@@ -209,7 +221,10 @@ mod test {
             vec![0, 1, 0, 0],
         ];
         assert_eq!(shd_from_adjacency(&g_truth, &g_guess), (1f64 / 6f64, 1));
-        let (d_truth, d_guess) = (PDAG::from_row_to_col_vecvec(g_truth), PDAG::from_row_to_col_vecvec(g_guess));
+        let (d_truth, d_guess) = (
+            PDAG::from_row_to_col_vecvec(g_truth),
+            PDAG::from_row_to_col_vecvec(g_guess),
+        );
 
         assert_eq!(shd(&d_truth, &d_guess), (1f64 / 6f64, 1));
     }
@@ -220,7 +235,10 @@ mod test {
         let g_guess = vec![vec![0]];
 
         assert_eq!(shd_from_adjacency(&g_truth, &g_guess), (0f64, 0));
-        let (d_truth, d_guess) = (PDAG::from_row_to_col_vecvec(g_truth), PDAG::from_row_to_col_vecvec(g_guess));
+        let (d_truth, d_guess) = (
+            PDAG::from_row_to_col_vecvec(g_truth),
+            PDAG::from_row_to_col_vecvec(g_guess),
+        );
 
         assert_eq!(shd(&d_truth, &d_guess), (0f64, 0));
 
@@ -233,7 +251,10 @@ mod test {
             vec![0, 0],
         ];
         assert_eq!(shd_from_adjacency(&g_truth, &g_guess), (1f64, 1));
-        let (d_truth, d_guess) = (PDAG::from_row_to_col_vecvec(g_truth), PDAG::from_row_to_col_vecvec(g_guess));
+        let (d_truth, d_guess) = (
+            PDAG::from_row_to_col_vecvec(g_truth),
+            PDAG::from_row_to_col_vecvec(g_guess),
+        );
         assert_eq!(shd(&d_truth, &d_guess), (1f64, 1));
 
         // 0 -> 1
@@ -248,7 +269,10 @@ mod test {
         ];
 
         assert_eq!(shd_from_adjacency(&g_truth, &g_guess), (1f64, 1));
-        let (d_truth, d_guess) = (PDAG::from_row_to_col_vecvec(g_truth), PDAG::from_row_to_col_vecvec(g_guess));
+        let (d_truth, d_guess) = (
+            PDAG::from_row_to_col_vecvec(g_truth),
+            PDAG::from_row_to_col_vecvec(g_guess),
+        );
 
         assert_eq!(shd(&d_truth, &d_guess), (1f64, 1));
 
@@ -263,7 +287,10 @@ mod test {
             vec![0, 0, 0],
         ];
         assert_eq!(shd_from_adjacency(&g_truth, &g_guess), (0f64, 0));
-        let (d_truth, d_guess) = (PDAG::from_row_to_col_vecvec(g_truth), PDAG::from_row_to_col_vecvec(g_guess));
+        let (d_truth, d_guess) = (
+            PDAG::from_row_to_col_vecvec(g_truth),
+            PDAG::from_row_to_col_vecvec(g_guess),
+        );
         assert_eq!(shd(&d_truth, &d_guess), (0f64, 0));
 
         let g_truth = vec![
@@ -277,7 +304,10 @@ mod test {
             vec![0, 0, 0],
         ];
         assert_eq!(shd_from_adjacency(&g_truth, &g_guess), (1f64, 3));
-        let (d_truth, d_guess) = (PDAG::from_row_to_col_vecvec(g_truth), PDAG::from_row_to_col_vecvec(g_guess));
+        let (d_truth, d_guess) = (
+            PDAG::from_row_to_col_vecvec(g_truth),
+            PDAG::from_row_to_col_vecvec(g_guess),
+        );
         assert_eq!(shd(&d_truth, &d_guess), (1f64, 3));
 
         let g_truth = vec![
@@ -293,7 +323,10 @@ mod test {
             vec![0, 2, 0, 0],
         ];
         assert_eq!(shd_from_adjacency(&g_truth, &g_guess), (1f64 / 6f64, 1));
-        let (d_truth, d_guess) = (PDAG::from_row_to_col_vecvec(g_truth), PDAG::from_row_to_col_vecvec(g_guess));
+        let (d_truth, d_guess) = (
+            PDAG::from_row_to_col_vecvec(g_truth),
+            PDAG::from_row_to_col_vecvec(g_guess),
+        );
 
         assert_eq!(shd(&d_truth, &d_guess), (1f64 / 6f64, 1));
     }

--- a/gadjid/src/graph_operations/shd.rs
+++ b/gadjid/src/graph_operations/shd.rs
@@ -150,8 +150,8 @@ mod test {
 
         assert_eq!(shd_from_adjacency(&g_truth, &g_guess), (0f64, 0));
         let (d_truth, d_guess) = (
-            PDAG::from_row_to_col_vecvec(g_truth),
-            PDAG::from_row_to_col_vecvec(g_guess),
+            PDAG::from_row_to_column_vecvec(g_truth),
+            PDAG::from_row_to_column_vecvec(g_guess),
         );
 
         assert_eq!(shd(&d_truth, &d_guess), (0f64, 0));
@@ -166,8 +166,8 @@ mod test {
         ];
         assert_eq!(shd_from_adjacency(&g_truth, &g_guess), (1f64, 1));
         let (d_truth, d_guess) = (
-            PDAG::from_row_to_col_vecvec(g_truth),
-            PDAG::from_row_to_col_vecvec(g_guess),
+            PDAG::from_row_to_column_vecvec(g_truth),
+            PDAG::from_row_to_column_vecvec(g_guess),
         );
         assert_eq!(shd(&d_truth, &d_guess), (1f64, 1));
 
@@ -184,8 +184,8 @@ mod test {
 
         assert_eq!(shd_from_adjacency(&g_truth, &g_guess), (1f64, 1));
         let (d_truth, d_guess) = (
-            PDAG::from_row_to_col_vecvec(g_truth),
-            PDAG::from_row_to_col_vecvec(g_guess),
+            PDAG::from_row_to_column_vecvec(g_truth),
+            PDAG::from_row_to_column_vecvec(g_guess),
         );
 
         assert_eq!(shd(&d_truth, &d_guess), (1f64, 1));
@@ -202,8 +202,8 @@ mod test {
         ];
         assert_eq!(shd_from_adjacency(&g_truth, &g_guess), (0f64, 0));
         let (d_truth, d_guess) = (
-            PDAG::from_row_to_col_vecvec(g_truth),
-            PDAG::from_row_to_col_vecvec(g_guess),
+            PDAG::from_row_to_column_vecvec(g_truth),
+            PDAG::from_row_to_column_vecvec(g_guess),
         );
 
         assert_eq!(shd(&d_truth, &d_guess), (0f64, 0));
@@ -222,8 +222,8 @@ mod test {
         ];
         assert_eq!(shd_from_adjacency(&g_truth, &g_guess), (1f64 / 6f64, 1));
         let (d_truth, d_guess) = (
-            PDAG::from_row_to_col_vecvec(g_truth),
-            PDAG::from_row_to_col_vecvec(g_guess),
+            PDAG::from_row_to_column_vecvec(g_truth),
+            PDAG::from_row_to_column_vecvec(g_guess),
         );
 
         assert_eq!(shd(&d_truth, &d_guess), (1f64 / 6f64, 1));
@@ -236,8 +236,8 @@ mod test {
 
         assert_eq!(shd_from_adjacency(&g_truth, &g_guess), (0f64, 0));
         let (d_truth, d_guess) = (
-            PDAG::from_row_to_col_vecvec(g_truth),
-            PDAG::from_row_to_col_vecvec(g_guess),
+            PDAG::from_row_to_column_vecvec(g_truth),
+            PDAG::from_row_to_column_vecvec(g_guess),
         );
 
         assert_eq!(shd(&d_truth, &d_guess), (0f64, 0));
@@ -252,8 +252,8 @@ mod test {
         ];
         assert_eq!(shd_from_adjacency(&g_truth, &g_guess), (1f64, 1));
         let (d_truth, d_guess) = (
-            PDAG::from_row_to_col_vecvec(g_truth),
-            PDAG::from_row_to_col_vecvec(g_guess),
+            PDAG::from_row_to_column_vecvec(g_truth),
+            PDAG::from_row_to_column_vecvec(g_guess),
         );
         assert_eq!(shd(&d_truth, &d_guess), (1f64, 1));
 
@@ -270,8 +270,8 @@ mod test {
 
         assert_eq!(shd_from_adjacency(&g_truth, &g_guess), (1f64, 1));
         let (d_truth, d_guess) = (
-            PDAG::from_row_to_col_vecvec(g_truth),
-            PDAG::from_row_to_col_vecvec(g_guess),
+            PDAG::from_row_to_column_vecvec(g_truth),
+            PDAG::from_row_to_column_vecvec(g_guess),
         );
 
         assert_eq!(shd(&d_truth, &d_guess), (1f64, 1));
@@ -288,8 +288,8 @@ mod test {
         ];
         assert_eq!(shd_from_adjacency(&g_truth, &g_guess), (0f64, 0));
         let (d_truth, d_guess) = (
-            PDAG::from_row_to_col_vecvec(g_truth),
-            PDAG::from_row_to_col_vecvec(g_guess),
+            PDAG::from_row_to_column_vecvec(g_truth),
+            PDAG::from_row_to_column_vecvec(g_guess),
         );
         assert_eq!(shd(&d_truth, &d_guess), (0f64, 0));
 
@@ -305,8 +305,8 @@ mod test {
         ];
         assert_eq!(shd_from_adjacency(&g_truth, &g_guess), (1f64, 3));
         let (d_truth, d_guess) = (
-            PDAG::from_row_to_col_vecvec(g_truth),
-            PDAG::from_row_to_col_vecvec(g_guess),
+            PDAG::from_row_to_column_vecvec(g_truth),
+            PDAG::from_row_to_column_vecvec(g_guess),
         );
         assert_eq!(shd(&d_truth, &d_guess), (1f64, 3));
 
@@ -324,8 +324,8 @@ mod test {
         ];
         assert_eq!(shd_from_adjacency(&g_truth, &g_guess), (1f64 / 6f64, 1));
         let (d_truth, d_guess) = (
-            PDAG::from_row_to_col_vecvec(g_truth),
-            PDAG::from_row_to_col_vecvec(g_guess),
+            PDAG::from_row_to_column_vecvec(g_truth),
+            PDAG::from_row_to_column_vecvec(g_guess),
         );
 
         assert_eq!(shd(&d_truth, &d_guess), (1f64 / 6f64, 1));

--- a/gadjid/src/graph_operations/shd.rs
+++ b/gadjid/src/graph_operations/shd.rs
@@ -149,7 +149,7 @@ mod test {
         let g_guess = vec![vec![0]];
 
         assert_eq!(shd_from_adjacency(&g_truth, &g_guess), (0f64, 0));
-        let (d_truth, d_guess) = (PDAG::from_vecvec(g_truth), PDAG::from_vecvec(g_guess));
+        let (d_truth, d_guess) = (PDAG::from_row_to_col_vecvec(g_truth), PDAG::from_row_to_col_vecvec(g_guess));
 
         assert_eq!(shd(&d_truth, &d_guess), (0f64, 0));
 
@@ -162,7 +162,7 @@ mod test {
             vec![0, 0],
         ];
         assert_eq!(shd_from_adjacency(&g_truth, &g_guess), (1f64, 1));
-        let (d_truth, d_guess) = (PDAG::from_vecvec(g_truth), PDAG::from_vecvec(g_guess));
+        let (d_truth, d_guess) = (PDAG::from_row_to_col_vecvec(g_truth), PDAG::from_row_to_col_vecvec(g_guess));
         assert_eq!(shd(&d_truth, &d_guess), (1f64, 1));
 
         // 0 -> 1
@@ -177,7 +177,7 @@ mod test {
         ];
 
         assert_eq!(shd_from_adjacency(&g_truth, &g_guess), (1f64, 1));
-        let (d_truth, d_guess) = (PDAG::from_vecvec(g_truth), PDAG::from_vecvec(g_guess));
+        let (d_truth, d_guess) = (PDAG::from_row_to_col_vecvec(g_truth), PDAG::from_row_to_col_vecvec(g_guess));
 
         assert_eq!(shd(&d_truth, &d_guess), (1f64, 1));
 
@@ -192,7 +192,7 @@ mod test {
             vec![0, 0, 0],
         ];
         assert_eq!(shd_from_adjacency(&g_truth, &g_guess), (0f64, 0));
-        let (d_truth, d_guess) = (PDAG::from_vecvec(g_truth), PDAG::from_vecvec(g_guess));
+        let (d_truth, d_guess) = (PDAG::from_row_to_col_vecvec(g_truth), PDAG::from_row_to_col_vecvec(g_guess));
 
         assert_eq!(shd(&d_truth, &d_guess), (0f64, 0));
 
@@ -209,7 +209,7 @@ mod test {
             vec![0, 1, 0, 0],
         ];
         assert_eq!(shd_from_adjacency(&g_truth, &g_guess), (1f64 / 6f64, 1));
-        let (d_truth, d_guess) = (PDAG::from_vecvec(g_truth), PDAG::from_vecvec(g_guess));
+        let (d_truth, d_guess) = (PDAG::from_row_to_col_vecvec(g_truth), PDAG::from_row_to_col_vecvec(g_guess));
 
         assert_eq!(shd(&d_truth, &d_guess), (1f64 / 6f64, 1));
     }
@@ -220,7 +220,7 @@ mod test {
         let g_guess = vec![vec![0]];
 
         assert_eq!(shd_from_adjacency(&g_truth, &g_guess), (0f64, 0));
-        let (d_truth, d_guess) = (PDAG::from_vecvec(g_truth), PDAG::from_vecvec(g_guess));
+        let (d_truth, d_guess) = (PDAG::from_row_to_col_vecvec(g_truth), PDAG::from_row_to_col_vecvec(g_guess));
 
         assert_eq!(shd(&d_truth, &d_guess), (0f64, 0));
 
@@ -233,7 +233,7 @@ mod test {
             vec![0, 0],
         ];
         assert_eq!(shd_from_adjacency(&g_truth, &g_guess), (1f64, 1));
-        let (d_truth, d_guess) = (PDAG::from_vecvec(g_truth), PDAG::from_vecvec(g_guess));
+        let (d_truth, d_guess) = (PDAG::from_row_to_col_vecvec(g_truth), PDAG::from_row_to_col_vecvec(g_guess));
         assert_eq!(shd(&d_truth, &d_guess), (1f64, 1));
 
         // 0 -> 1
@@ -248,7 +248,7 @@ mod test {
         ];
 
         assert_eq!(shd_from_adjacency(&g_truth, &g_guess), (1f64, 1));
-        let (d_truth, d_guess) = (PDAG::from_vecvec(g_truth), PDAG::from_vecvec(g_guess));
+        let (d_truth, d_guess) = (PDAG::from_row_to_col_vecvec(g_truth), PDAG::from_row_to_col_vecvec(g_guess));
 
         assert_eq!(shd(&d_truth, &d_guess), (1f64, 1));
 
@@ -263,7 +263,7 @@ mod test {
             vec![0, 0, 0],
         ];
         assert_eq!(shd_from_adjacency(&g_truth, &g_guess), (0f64, 0));
-        let (d_truth, d_guess) = (PDAG::from_vecvec(g_truth), PDAG::from_vecvec(g_guess));
+        let (d_truth, d_guess) = (PDAG::from_row_to_col_vecvec(g_truth), PDAG::from_row_to_col_vecvec(g_guess));
         assert_eq!(shd(&d_truth, &d_guess), (0f64, 0));
 
         let g_truth = vec![
@@ -277,7 +277,7 @@ mod test {
             vec![0, 0, 0],
         ];
         assert_eq!(shd_from_adjacency(&g_truth, &g_guess), (1f64, 3));
-        let (d_truth, d_guess) = (PDAG::from_vecvec(g_truth), PDAG::from_vecvec(g_guess));
+        let (d_truth, d_guess) = (PDAG::from_row_to_col_vecvec(g_truth), PDAG::from_row_to_col_vecvec(g_guess));
         assert_eq!(shd(&d_truth, &d_guess), (1f64, 3));
 
         let g_truth = vec![
@@ -293,7 +293,7 @@ mod test {
             vec![0, 2, 0, 0],
         ];
         assert_eq!(shd_from_adjacency(&g_truth, &g_guess), (1f64 / 6f64, 1));
-        let (d_truth, d_guess) = (PDAG::from_vecvec(g_truth), PDAG::from_vecvec(g_guess));
+        let (d_truth, d_guess) = (PDAG::from_row_to_col_vecvec(g_truth), PDAG::from_row_to_col_vecvec(g_guess));
 
         assert_eq!(shd(&d_truth, &d_guess), (1f64 / 6f64, 1));
     }

--- a/gadjid/src/lib.rs
+++ b/gadjid/src/lib.rs
@@ -67,7 +67,7 @@ mod test {
             }
         }
 
-        PDAG::from_row_to_col_vecvec(adj)
+        PDAG::from_row_to_column_vecvec(adj)
     }
 
     fn hashset_to_sorted_vec<V: std::cmp::Ord + Copy>(set: &FxHashSet<V>) -> Vec<V> {

--- a/gadjid/src/lib.rs
+++ b/gadjid/src/lib.rs
@@ -67,7 +67,7 @@ mod test {
             }
         }
 
-        PDAG::from_vecvec(adj)
+        PDAG::from_row_to_col_vecvec(adj)
     }
 
     fn hashset_to_sorted_vec<V: std::cmp::Ord + Copy>(set: &FxHashSet<V>) -> Vec<V> {

--- a/gadjid/src/partially_directed_acyclic_graph.rs
+++ b/gadjid/src/partially_directed_acyclic_graph.rs
@@ -194,7 +194,7 @@ impl fmt::Display for LoadError {
 impl PDAG {
     // TODO: from_row_major and from_col_major are very similar, unify as much as possible for clarity
 
-    /// Creates a PDAG from a adjacency matrix traversed in row-major order.
+    /// Creates a PDAG from an edgelist, yielding entries in a row-by-row order.
     ///
     /// If there is an undirected edge between node i and j, the edgelist may yield
     /// (i, j, 2) and (j, i, 2). Yielding only one is also fine, but yielding
@@ -344,7 +344,7 @@ impl PDAG {
         Ok(pdag)
     }
 
-    /// Creates a PDAG from a adjacency matrix traversed in column-major order.
+    /// Creates a PDAG from an edgelist, yielding entries in a column-by-column order.
     ///
     /// If there is an undirected edge between node i and j, the edgelist may yield
     /// (i, j, 2) and (j, i, 2). Yielding only one is also fine, but yielding

--- a/gadjid/src/partially_directed_acyclic_graph.rs
+++ b/gadjid/src/partially_directed_acyclic_graph.rs
@@ -78,11 +78,10 @@ pub struct PDAG {
 pub enum Structure {
     /// The PDAG contains no undirected edges and is acyclic, so it is a DAG.
     DAG,
-    /// The graph contains directed and undirected edges and no directed cycles. 
+    /// The graph contains directed and undirected edges and no directed cycles.
     /// It is however not guaranteed to be a CPDAG.
     CPDAG,
 }
-
 
 /// Will display the adjacency matrix of the PDAG, encoded as row-to-column adjacency matrix.
 impl fmt::Display for PDAG {
@@ -500,8 +499,8 @@ impl PDAG {
         Ok(pdag)
     }
 
-    /// Creates a PDAG from a row-major encoded adjacency matrix. 
-    /// An entry of 1 at position `[i,j]` indicates a directed edge `i -> j`, 
+    /// Creates a PDAG from a row-major encoded adjacency matrix.
+    /// An entry of 1 at position `[i,j]` indicates a directed edge `i -> j`,
     /// the opposite of how [`from_col_to_row_vecvec`] does it.
     /// An entry of 2 at position `[i,j]` and/or `[j,i]` indicates an undirected edge between `i` and `j`.
     pub fn from_row_to_col_vecvec(dense: Vec<Vec<i8>>) -> Self {
@@ -517,8 +516,8 @@ impl PDAG {
         pdag
     }
 
-    /// Creates a PDAG from a row_major adjacency matrix. 
-    /// An entry of 1 at position `[i,j]` indicates a directed edge `j -> i`, 
+    /// Creates a PDAG from a row_major adjacency matrix.
+    /// An entry of 1 at position `[i,j]` indicates a directed edge `j -> i`,
     /// the opposite of how [`from_row_to_col_vecvec`] does it.
     /// An entry of 2 at position `[i,j]` and/or `[j,i]` indicates an undirected edge between `i` and `j`.
     pub fn from_col_to_row_vecvec(vecvec: Vec<Vec<i8>>) -> Self {

--- a/gadjid/src/partially_directed_acyclic_graph.rs
+++ b/gadjid/src/partially_directed_acyclic_graph.rs
@@ -78,10 +78,13 @@ pub struct PDAG {
 pub enum Structure {
     /// The PDAG contains no undirected edges and is acyclic, so it is a DAG.
     DAG,
-    /// The PDAG contains undirected edges. It is however not guaranteed to be a CPDAG.
+    /// The graph contains directed and undirected edges and no directed cycles. 
+    /// It is however not guaranteed to be a CPDAG.
     CPDAG,
 }
 
+
+/// Will display the adjacency matrix of the PDAG, encoded as row-to-column adjacency matrix.
 impl fmt::Display for PDAG {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut adjacency = vec![vec![0; self.n_nodes]; self.n_nodes];

--- a/gadjid/src/partially_directed_acyclic_graph.rs
+++ b/gadjid/src/partially_directed_acyclic_graph.rs
@@ -503,7 +503,7 @@ impl PDAG {
     /// An entry of 1 at position `[i,j]` indicates a directed edge `i -> j`,
     /// the opposite of how [`from_col_to_row_vecvec`] does it.
     /// An entry of 2 at position `[i,j]` and/or `[j,i]` indicates an undirected edge between `i` and `j`.
-    pub fn from_row_to_col_vecvec(dense: Vec<Vec<i8>>) -> Self {
+    pub fn from_row_to_column_vecvec(dense: Vec<Vec<i8>>) -> Self {
         let edgelist = Edgelist::from_vecvec(dense);
         let mut pdag = PDAG::try_from_row_major(edgelist).unwrap();
 
@@ -551,7 +551,7 @@ impl PDAG {
             }
         }
 
-        PDAG::from_row_to_col_vecvec(adjacency)
+        PDAG::from_row_to_column_vecvec(adjacency)
     }
 
     /// Creates a random vecvec of a PDAG with random edges with the given edge density and size.
@@ -590,7 +590,7 @@ impl PDAG {
 
     /// Creates a random PDAG with random edges with the given edge density and size.
     pub fn random_pdag(edge_density: f64, graph_size: usize, mut rng: impl rand::RngCore) -> PDAG {
-        PDAG::from_row_to_col_vecvec(PDAG::_random_pdag_vecvec(
+        PDAG::from_row_to_column_vecvec(PDAG::_random_pdag_vecvec(
             edge_density,
             graph_size,
             &mut rng,
@@ -662,7 +662,7 @@ mod test {
             vec![1, 0],
         ];
 
-        PDAG::from_row_to_col_vecvec(dense);
+        PDAG::from_row_to_column_vecvec(dense);
     }
 
     #[test]
@@ -673,7 +673,7 @@ mod test {
             vec![2, 0],
         ];
 
-        PDAG::from_row_to_col_vecvec(dense);
+        PDAG::from_row_to_column_vecvec(dense);
     }
 
     #[test]
@@ -684,7 +684,7 @@ mod test {
             vec![0, 0, 0],
         ];
 
-        PDAG::from_row_to_col_vecvec(dense);
+        PDAG::from_row_to_column_vecvec(dense);
     }
 
     #[test]
@@ -695,7 +695,7 @@ mod test {
             vec![0, 0],
         ];
 
-        let cpdag = PDAG::from_row_to_col_vecvec(dense);
+        let cpdag = PDAG::from_row_to_column_vecvec(dense);
 
         assert_eq!(cpdag.n_nodes, 2);
 
@@ -719,7 +719,7 @@ mod test {
             vec![0, 0, 0, 0],
         ];
 
-        let cpdag = PDAG::from_row_to_col_vecvec(dense);
+        let cpdag = PDAG::from_row_to_column_vecvec(dense);
 
         assert_eq!(cpdag.n_nodes, 4);
         assert_eq!(
@@ -758,7 +758,7 @@ mod test {
             vec![2, 0, 0],
         ];
 
-        let cpdag = PDAG::from_row_to_col_vecvec(dense);
+        let cpdag = PDAG::from_row_to_column_vecvec(dense);
 
         assert_eq!(cpdag.n_nodes, 3);
 
@@ -784,7 +784,7 @@ mod test {
             vec![0, 0],
         ];
 
-        let dag = PDAG::from_row_to_col_vecvec(dense);
+        let dag = PDAG::from_row_to_column_vecvec(dense);
 
         assert_eq!(dag.n_nodes, 2);
 
@@ -808,7 +808,7 @@ mod test {
             vec![0, 0, 0, 0],
         ];
 
-        let dag = PDAG::from_row_to_col_vecvec(dense);
+        let dag = PDAG::from_row_to_column_vecvec(dense);
 
         assert_eq!(dag.n_nodes, 4);
         assert_eq!(
@@ -846,7 +846,7 @@ mod test {
             vec![0, 0, 0],
         ];
 
-        let dag = PDAG::from_row_to_col_vecvec(dense);
+        let dag = PDAG::from_row_to_column_vecvec(dense);
 
         assert_eq!(dag.n_nodes, 3);
 
@@ -877,7 +877,7 @@ mod test {
             }
 
             // construct the DAG from the original and transposed adjacency matrix
-            let row_major_dag = PDAG::from_row_to_col_vecvec(adjacency);
+            let row_major_dag = PDAG::from_row_to_column_vecvec(adjacency);
             let col_major_dag = PDAG::from_col_to_row_vecvec(transpose_adjacency);
 
             // the final representations of the DAG should be 100% equal
@@ -929,7 +929,7 @@ mod test {
         ];
 
         for (i, dense) in dense_matrices.iter().enumerate() {
-            let cpdag = PDAG::from_row_to_col_vecvec(dense.clone());
+            let cpdag = PDAG::from_row_to_column_vecvec(dense.clone());
 
             for n in 0..cpdag.n_nodes {
                 let mut children = cpdag.children_of(n).to_vec();
@@ -976,7 +976,7 @@ mod test {
             vec![0, 0, 1],
             vec![0, 1, 0],
         ];
-        let _ = PDAG::from_row_to_col_vecvec(g_truth);
+        let _ = PDAG::from_row_to_column_vecvec(g_truth);
     }
 
     #[test]
@@ -987,7 +987,7 @@ mod test {
             vec![0, 0, 1],
             vec![1, 0, 0],
         ];
-        let _ = PDAG::from_row_to_col_vecvec(g_truth);
+        let _ = PDAG::from_row_to_column_vecvec(g_truth);
     }
 
     #[test]
@@ -998,6 +998,6 @@ mod test {
             vec![0, 0, 1],
             vec![1, 1, 0],
         ];
-        let _ = PDAG::from_row_to_col_vecvec(g_truth);
+        let _ = PDAG::from_row_to_column_vecvec(g_truth);
     }
 }

--- a/gadjid_python/Cargo.lock
+++ b/gadjid_python/Cargo.lock
@@ -59,7 +59,7 @@ checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "gadjid"
-version = "0.1.0-a.0"
+version = "0.1.0-a.1"
 dependencies = [
  "rand",
  "rand_chacha",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "gadjid_python"
-version = "0.1.0-a.0"
+version = "0.1.0-a.1"
 dependencies = [
  "anyhow",
  "gadjid",
@@ -96,9 +96,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "indoc"
-version = "2.0.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "libc"
@@ -351,9 +351,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
@@ -392,15 +392,15 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "smallvec"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "syn"
-version = "2.0.53"
+version = "2.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
+checksum = "002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/gadjid_python/Cargo.lock
+++ b/gadjid_python/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "bitflags"

--- a/gadjid_python/Cargo.toml
+++ b/gadjid_python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gadjid_python"
-version = "0.1.0-a.0"
+version = "0.1.0-a.1"
 edition = "2021"
 license = "MPL-2.0"
 publish = false

--- a/gadjid_python/README.md
+++ b/gadjid_python/README.md
@@ -46,7 +46,7 @@ Gguess = np.array([
     [0, 0, 0, 0, 0]
 ], dtype=np.int8)
 
-print(ancestor_aid(Gtrue, Gguess))
+print(ancestor_aid(Gtrue, Gguess, edge_direction="from row to column"))
 print(shd(Gtrue, Gguess))
 ```
 
@@ -82,17 +82,26 @@ and the number of wrongly inferred causal effects, `mistake_count`.
 There are $p(p-1)$ pairwise causal effects to infer in graphs with $p$ nodes
 and we define normalisation as  `normalised_distance = mistake_count / p(p-1)`.
 
-All graphs are assumed simple, that is, at most one edge is allowed between any two nodes.
-An adjacency matrix for a DAG may only contain 0s and 1s;
-a `1` in row `s` and column `t` codes a directed edge `Xₛ → Xₜ`;
-DAG inputs are validated for acyclicity.
-An adjacency matrix for a CPDAG may only contain 0s, 1s and 2s;
-a `2` in row `s` and column `t` codes a undirected edge `Xₛ — Xₜ`
-(an additional `2` in row `t` and column `s` is ignored; only one of the two entries is required to code an undirected edge);
-CPDAG inputs are not validated and __the user needs to ensure the adjacency matrix indeed codes a valid CPDAG (instead of just a PDAG)__.
-You may also calculate the SID between DAGs via `parent_aid(DAGtrue, DAGguess)`,
-but we recommend `ancestor_aid` and `oset_aid` and for CPDAG inputs our `parent_aid` does not coincide with the SID
+You may also calculate the SID between DAGs via `parent_aid`,
+but we recommend `ancestor_aid` and `oset_aid`, and for CPDAG inputs our `parent_aid` does not coincide with the SID
 (see also our accompanying article).
+
+If `edge_direction="from row to column"`, then
+a `1` in row `r` and column `c` codes a directed edge `r → c`;
+if `edge_direction="from column to row"`, then
+a `1` in row `r` and column `c` codes a directed edge `c → r`;
+for either setting of `edge_direction`,
+a `2` in row `r` and column `c` codes an undirected edge `r – t`
+(an additional `2` in row `c` and column `r` is ignored;
+one of the two entries is sufficient to code an undirected edge).
+
+An adjacency matrix for a DAG may only contain 0s and 1s.
+An adjacency matrix for a CPDAG may only contain 0s, 1s and 2s.
+DAG and CPDAG inputs are validated for acyclicity. 
+However, for CPDAG inputs, __the user needs to ensure the adjacency 
+matrix indeed codes a valid CPDAG (instead of just a PDAG)__.
+
+
 
 
 ## Empirical Runtime Analysis

--- a/gadjid_python/README.md
+++ b/gadjid_python/README.md
@@ -1,7 +1,7 @@
 # Adjustment Identification Distance: A 𝚐𝚊𝚍𝚓𝚒𝚍 for Causal Structure Learning
 
 This is an early release of 𝚐𝚊𝚍𝚓𝚒𝚍 🐥 and feedback is very welcome!
-Just [open an issue](https://github.com/CausalDisco/gadjid/issues/new/choose) on our github repository.
+Just [open an issue](https://github.com/CausalDisco/gadjid/issues/new/choose) on github.
 
 If you publish research using 𝚐𝚊𝚍𝚓𝚒𝚍, please cite
 [our article](https://doi.org/10.48550/arXiv.2402.08616)
@@ -64,15 +64,17 @@ structural intervention distance for directed acyclic graphs as a special case. 
 
 ## Implemented Distances
 
-* `ancestor_aid(Gtrue, Gguess)`
-* `oset_aid(Gtrue, Gguess)`
-* `parent_aid(Gtrue, Gguess)`
+* `ancestor_aid(Gtrue, Gguess, edge_direction)`
+* `oset_aid(Gtrue, Gguess, edge_direction)`
+* `parent_aid(Gtrue, Gguess, edge_direction)`
 * for convenience, the following distances are implemented, too
     * `shd(Gtrue, Gguess)`
-    * `sid(Gtrue, Gguess)` – only for DAGs!
+    * `sid(Gtrue, Gguess, edge_direction)` – only for DAGs!
 
-where Gtrue and Gguess are adjacency matrices of a DAG or CPDAG.
-The functions are not symmetric in their input:
+where `Gtrue` and `Gguess` are adjacency matrices of a DAG or CPDAG
+and `edge_direction` determines whether a `1` at r-th row and c-th column of an adjacency matrix
+codes the edge `r → c` (`edge_direction="from row to column"`) or `c → r` (`edge_direction="from column to row"`).
+The functions are not symmetric in their inputs:
 To calculate a distance,
 identifying formulas for causal effects are inferred in the graph `Gguess`
 and verified against the graph `Gtrue`.
@@ -82,8 +84,8 @@ and the number of wrongly inferred causal effects, `mistake_count`.
 There are $p(p-1)$ pairwise causal effects to infer in graphs with $p$ nodes
 and we define normalisation as  `normalised_distance = mistake_count / p(p-1)`.
 
-You may also calculate the SID between DAGs via `parent_aid`,
-but we recommend `ancestor_aid` and `oset_aid`, and for CPDAG inputs our `parent_aid` does not coincide with the SID
+You may also calculate the SID between DAGs via `parent_aid(DAGtrue, DAGguess, edge_direction)`,
+but we recommend `ancestor_aid` and `oset_aid` and for CPDAG inputs the `parent_aid` does not coincide with the SID
 (see also our accompanying article).
 
 If `edge_direction="from row to column"`, then
@@ -91,17 +93,15 @@ a `1` in row `r` and column `c` codes a directed edge `r → c`;
 if `edge_direction="from column to row"`, then
 a `1` in row `r` and column `c` codes a directed edge `c → r`;
 for either setting of `edge_direction`,
-a `2` in row `r` and column `c` codes an undirected edge `r – t`
+a `2` in row `r` and column `c` codes an undirected edge `r – c`
 (an additional `2` in row `c` and column `r` is ignored;
 one of the two entries is sufficient to code an undirected edge).
 
 An adjacency matrix for a DAG may only contain 0s and 1s.
 An adjacency matrix for a CPDAG may only contain 0s, 1s and 2s.
-DAG and CPDAG inputs are validated for acyclicity. 
-However, for CPDAG inputs, __the user needs to ensure the adjacency 
+DAG and CPDAG inputs are validated for acyclicity.
+However, for CPDAG inputs, __the user needs to ensure the adjacency
 matrix indeed codes a valid CPDAG (instead of just a PDAG)__.
-
-
 
 
 ## Empirical Runtime Analysis
@@ -111,7 +111,7 @@ Here, for a graph with $p$ nodes,
 sparse graphs have $10p$ edges in expectation,
 dense graphs have $0.3p(p-1)/2$ edges in expectation,
 and
-sparse graphs have $0.75p$ edges in expectation.
+x-sparse graphs have $0.75p$ edges in expectation.
 
 __Maximum graph size feasible within 1 minute__
 
@@ -122,6 +122,9 @@ __Maximum graph size feasible within 1 minute__
 | Oset-AID     |    546 |   250 |
 | SID in R     |    255 |   239 |
 
+Results obtained with 𝚐𝚊𝚍𝚓𝚒𝚍 v0.0.1 using the Python interface
+and the SID R package v1.1 from CRAN.
+
 __Average runtime__
 | Method       | x-sparse ($p=1000$) | sparse ($p=256$) | dense ($p=239$) |
 |--------------|--------------------:|-----------------:|----------------:|
@@ -129,6 +132,9 @@ __Average runtime__
 | Ancestor-AID |              2.7 ms |          38.7 ms |          226 ms |
 | Oset-AID     |              3.2 ms |          4.69 s  |         47.3 s  |
 | SID in R     |             ~1–2 h  |           ~60 s  |          ~60 s  |
+
+Results obtained with 𝚐𝚊𝚍𝚓𝚒𝚍 v0.0.1 using the Python interface
+and the SID R package v1.1 from CRAN.
 
 
 ## LICENSE

--- a/gadjid_python/python/gadjid/example.py
+++ b/gadjid_python/python/gadjid/example.py
@@ -11,7 +11,7 @@ from gadjid import parent_aid
 
 rng = np.random.default_rng(0)
 
-ROW_TO_COL = "from row to col"
+ROW_TO_COL = "from row to column"
 
 
 def random_dag(size, probability):

--- a/gadjid_python/python/gadjid/example.py
+++ b/gadjid_python/python/gadjid/example.py
@@ -28,7 +28,8 @@ def run_parent_aid(size=500, probability=0.1):
         f"\nCalculating the Parent-AID between {size}-node DAGs "
         f"with {100 * (probability):.0f}% of all possible edges\n\n"
         f"    >>> parent_aid(random_dag({size}, {probability}), "
-        f"random_dag({size}, {probability}))"
+        f"random_dag({size}, {probability})"
+        ', edge_direction="from row to column")'
     )
 
     DAGa = random_dag(size, probability)

--- a/gadjid_python/python/gadjid/example.py
+++ b/gadjid_python/python/gadjid/example.py
@@ -29,7 +29,7 @@ def run_parent_aid(size=500, probability=0.1):
         f"with {100 * (probability):.0f}% of all possible edges\n\n"
         f"    >>> parent_aid(random_dag({size}, {probability}), "
         f"random_dag({size}, {probability})"
-        ', edge_direction="from row to column")'
+        f', edge_direction="{ROW_TO_COL}")'
     )
 
     DAGa = random_dag(size, probability)

--- a/gadjid_python/python/gadjid/example.py
+++ b/gadjid_python/python/gadjid/example.py
@@ -13,6 +13,7 @@ rng = np.random.default_rng(0)
 
 ROW_TO_COL = "from row to col"
 
+
 def random_dag(size, probability):
     """Draw adjacency matrix of a random DAG."""
     adj = rng.binomial(1, probability, size=(size, size)).astype(np.int8)

--- a/gadjid_python/python/gadjid/example.py
+++ b/gadjid_python/python/gadjid/example.py
@@ -8,7 +8,6 @@ import numpy as np
 
 from gadjid import parent_aid
 
-
 rng = np.random.default_rng(0)
 
 ROW_TO_COL = "from row to column"

--- a/gadjid_python/python/gadjid/example.py
+++ b/gadjid_python/python/gadjid/example.py
@@ -31,7 +31,7 @@ def run_parent_aid(size=500, probability=.1):
     DAGb = random_dag(size, probability)
 
     tic = timer()
-    print(f"    {parent_aid(DAGa, DAGb)}")
+    print(f"    {parent_aid(DAGa, DAGb, edge_direction="from row to col")}")
     toc = timer() - tic
     print(
         f"\ntook {toc:.3f} seconds.\n\n"

--- a/gadjid_python/python/gadjid/example.py
+++ b/gadjid_python/python/gadjid/example.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from gadjid import parent_aid
 
+
 rng = np.random.default_rng(0)
 
 ROW_TO_COL = "from row to column"

--- a/gadjid_python/python/gadjid/example.py
+++ b/gadjid_python/python/gadjid/example.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
 """Run a quick example."""
+
 # wall time
 from time import perf_counter as timer
 
@@ -10,6 +11,7 @@ from gadjid import parent_aid
 
 rng = np.random.default_rng(0)
 
+ROW_TO_COL = "from row to col"
 
 def random_dag(size, probability):
     """Draw adjacency matrix of a random DAG."""
@@ -19,24 +21,25 @@ def random_dag(size, probability):
     return adj[perm, :][:, perm]
 
 
-def run_parent_aid(size=500, probability=.1):
+def run_parent_aid(size=500, probability=0.1):
     """Compare two DAGs using parent_aid."""
     print(
         f"\nCalculating the Parent-AID between {size}-node DAGs "
         f"with {100 * (probability):.0f}% of all possible edges\n\n"
         f"    >>> parent_aid(random_dag({size}, {probability}), "
-        f"random_dag({size}, {probability}))")
+        f"random_dag({size}, {probability}))"
+    )
 
     DAGa = random_dag(size, probability)
     DAGb = random_dag(size, probability)
 
     tic = timer()
-    print(f"    {parent_aid(DAGa, DAGb, edge_direction="from row to col")}")
+    print(f"    {parent_aid(DAGa, DAGb, edge_direction=ROW_TO_COL)}")
     toc = timer() - tic
     print(
         f"\ntook {toc:.3f} seconds.\n\n"
         "Compare this to the runtime for calculating the SID in R via \n\n    "
-        "R -e \"library(SID); "
+        'R -e "library(SID); '
         f"s <- structIntervDist(randomDAG({size}, {probability:.2f}), "
-        f"randomDAG({size}, {probability:.2f}));\"\n"
-        )
+        f'randomDAG({size}, {probability:.2f}));"\n'
+    )

--- a/gadjid_python/src/lib.rs
+++ b/gadjid_python/src/lib.rs
@@ -15,9 +15,6 @@ use ::gadjid::graph_operations::shd as rust_shd;
 use ::gadjid::graph_operations::sid as rust_sid;
 use ::gadjid::EdgelistIterator;
 use ::gadjid::PDAG;
-use anyhow::bail;
-use pyo3::exceptions::PyTypeError;
-use pyo3::prelude::*;
 
 use numpy_ndarray_handler::try_from as try_from_dense;
 use scipy_sparse_handler::try_from as try_from_sparse;
@@ -74,7 +71,7 @@ fn edge_direction_semantics_is_row_to_col(edge_direction: &str) -> PyResult<bool
     match edge_direction {
         ROW_TO_COL => Ok(true),
         COL_TO_ROW => Ok(false),
-        _ => Err(PyErr::new::<PyTypeError, _>(format!(
+        _ => Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
             "edge_direction argument must be either a string containing (exactly) '{}' or '{}'",
             ROW_TO_COL, COL_TO_ROW
         ))),

--- a/gadjid_python/src/lib.rs
+++ b/gadjid_python/src/lib.rs
@@ -114,8 +114,9 @@ pub fn parent_aid(g_true: &PyAny, g_guess: &PyAny, edge_direction: &str) -> PyRe
 
 /// Structural Hamming Distance between two DAG / CPDAG adjacency matrices (sparse or dense)
 #[pyfunction]
-pub fn shd(g_true: &PyAny, g_guess: &PyAny, edge_direction: &str) -> PyResult<(f64, usize)> {
-    let row_to_col = edge_direction_is_row_to_col(edge_direction)?;
+pub fn shd(g_true: &PyAny, g_guess: &PyAny) -> PyResult<(f64, usize)> {
+    // set row_to_col variable to 'true', but it doesn't matter
+    let row_to_col = true;
     let graph_truth = graph_from_pyobject(g_true, row_to_col)?;
     let graph_guess = graph_from_pyobject(g_guess, row_to_col)?;
     let (normalized_distance, n_errors) = rust_shd(&graph_truth, &graph_guess);

--- a/gadjid_python/src/lib.rs
+++ b/gadjid_python/src/lib.rs
@@ -15,6 +15,9 @@ use ::gadjid::graph_operations::shd as rust_shd;
 use ::gadjid::graph_operations::sid as rust_sid;
 use ::gadjid::EdgelistIterator;
 use ::gadjid::PDAG;
+use anyhow::bail;
+use pyo3::exceptions::PyTypeError;
+use pyo3::prelude::*;
 
 use numpy_ndarray_handler::try_from as try_from_dense;
 use scipy_sparse_handler::try_from as try_from_sparse;
@@ -64,47 +67,78 @@ fn gadjid(_py: Python, m: &PyModule) -> PyResult<()> {
     Ok(())
 }
 
+const ROW_TO_COL: &str = "row->col";
+const COL_TO_ROW: &str = "col->row";
+
+fn edge_direction_semantics_is_row_to_col(edge_direction: &str) -> PyResult<bool> {
+    match edge_direction {
+        ROW_TO_COL => Ok(true),
+        COL_TO_ROW => Ok(false),
+        _ => Err(PyErr::new::<PyTypeError, _>(format!(
+            "edge_direction argument must be either a string containing (exactly) '{}' or '{}'",
+            ROW_TO_COL, COL_TO_ROW
+        ))),
+    }
+}
+
 /// Ancestor Adjustment Identification Distance between two DAG / CPDAG adjacency matrices (sparse or dense)
 #[pyfunction]
-pub fn ancestor_aid(g_true: &PyAny, g_guess: &PyAny) -> PyResult<(f64, usize)> {
-    let graph_truth = graph_from_pyobject(g_true)?;
-    let graph_guess = graph_from_pyobject(g_guess)?;
+pub fn ancestor_aid(
+    g_true: &PyAny,
+    g_guess: &PyAny,
+    edge_semantics: &str,
+) -> PyResult<(f64, usize)> {
+    let row_to_col = edge_direction_semantics_is_row_to_col(edge_semantics)?;
+    let graph_truth = graph_from_pyobject(g_true, row_to_col)?;
+    let graph_guess = graph_from_pyobject(g_guess, row_to_col)?;
     let (normalized_distance, n_errors) = rust_ancestor_aid(&graph_truth, &graph_guess);
     Ok((normalized_distance, n_errors))
 }
 
 /// Optimal Adjustment Identification Distance between two DAG / CPDAG adjacency matrices (sparse or dense)
 #[pyfunction]
-pub fn oset_aid(g_true: &PyAny, g_guess: &PyAny) -> PyResult<(f64, usize)> {
-    let graph_truth = graph_from_pyobject(g_true)?;
-    let graph_guess = graph_from_pyobject(g_guess)?;
+pub fn oset_aid(g_true: &PyAny, g_guess: &PyAny, edge_semantics: &str) -> PyResult<(f64, usize)> {
+    let row_to_col = edge_direction_semantics_is_row_to_col(edge_semantics)?;
+    let graph_truth = graph_from_pyobject(g_true, row_to_col)?;
+    let graph_guess = graph_from_pyobject(g_guess, row_to_col)?;
     let (normalized_distance, n_errors) = rust_oset_aid(&graph_truth, &graph_guess);
     Ok((normalized_distance, n_errors))
 }
 
 /// Parent Adjustment Identification Distance between two DAG / CPDAG adjacency matrices (sparse or dense)
 #[pyfunction]
-pub fn parent_aid(g_true: &PyAny, g_guess: &PyAny) -> PyResult<(f64, usize)> {
-    let graph_truth = graph_from_pyobject(g_true)?;
-    let graph_guess = graph_from_pyobject(g_guess)?;
+pub fn parent_aid(
+    g_true: &PyAny,
+    g_guess: &PyAny,
+    edge_semantics: &str,
+) -> PyResult<(f64, usize)> {
+    let row_to_col = edge_direction_semantics_is_row_to_col(edge_semantics)?;
+    let graph_truth = graph_from_pyobject(g_true, row_to_col)?;
+    let graph_guess = graph_from_pyobject(g_guess, row_to_col)?;
     let (normalized_distance, n_errors) = rust_parent_aid(&graph_truth, &graph_guess);
     Ok((normalized_distance, n_errors))
 }
 
 /// Structural Hamming Distance between two DAG / CPDAG adjacency matrices (sparse or dense)
 #[pyfunction]
-pub fn shd(g_true: &PyAny, g_guess: &PyAny) -> PyResult<(f64, usize)> {
-    let graph_truth = graph_from_pyobject(g_true)?;
-    let graph_guess = graph_from_pyobject(g_guess)?;
+pub fn shd(g_true: &PyAny, g_guess: &PyAny, edge_semantics: &str) -> PyResult<(f64, usize)> {
+    let row_to_col = edge_direction_semantics_is_row_to_col(edge_semantics)?;
+    let graph_truth = graph_from_pyobject(g_true, row_to_col)?;
+    let graph_guess = graph_from_pyobject(g_guess, row_to_col)?;
     let (normalized_distance, n_errors) = rust_shd(&graph_truth, &graph_guess);
     Ok((normalized_distance, n_errors))
 }
 
 /// Structural Identification Distance between two DAG adjacency matrices (sparse or dense)
 #[pyfunction]
-pub fn sid(g_true: &PyAny, g_guess: &PyAny) -> anyhow::Result<(f64, usize)> {
-    let dag_truth = graph_from_pyobject(g_true)?;
-    let dag_guess = graph_from_pyobject(g_guess)?;
+pub fn sid(
+    g_true: &PyAny,
+    g_guess: &PyAny,
+    edge_semantics: &str,
+) -> anyhow::Result<(f64, usize)> {
+    let row_to_col = edge_direction_semantics_is_row_to_col(edge_semantics)?;
+    let dag_truth = graph_from_pyobject(g_true, row_to_col)?;
+    let dag_guess = graph_from_pyobject(g_guess, row_to_col)?;
     let (normalized_distance, n_errors) = rust_sid(&dag_truth, &dag_guess)?;
     Ok((normalized_distance, n_errors))
 }
@@ -112,11 +146,11 @@ pub fn sid(g_true: &PyAny, g_guess: &PyAny) -> anyhow::Result<(f64, usize)> {
 /// Load a graph from a 2D numpy or scipy sparse matrix.
 /// Will load a matrix into a PDAG, automatically loading into a DAG and checking
 /// acyclicity. If undirected edges present, assumes that it encodes as valid CPDAG
-fn graph_from_pyobject(ob: &PyAny) -> anyhow::Result<PDAG> {
+fn graph_from_pyobject(ob: &PyAny, is_row_to_col: bool) -> anyhow::Result<PDAG> {
     // first try to load as np dense matrix
-    match try_from_dense(ob) {
+    match try_from_dense(ob, is_row_to_col) {
         Ok(load_result) => Ok(load_result),
-        Err(e1) => match try_from_sparse(ob) {
+        Err(e1) => match try_from_sparse(ob, is_row_to_col) {
             Ok(graph) => Ok(graph),
             Err(e2) => {
                 let msg = format!(
@@ -135,10 +169,10 @@ as np ndarray or scipy sparse matrix.
 /// acyclicity. If undirected edges present, assumes that it encodes as valid CPDAG
 pub(crate) fn graph_from_iterator(
     iterator: impl Iterator<Item = (usize, usize, i8)>,
-    row_major: bool,
+    row_to_col: bool,
     graph_size: usize,
 ) -> anyhow::Result<PDAG> {
-    match row_major {
+    match row_to_col {
         true => match PDAG::try_from_row_major(EdgelistIterator::into_row_major_edgelist(
             iterator, graph_size,
         )) {
@@ -147,6 +181,7 @@ pub(crate) fn graph_from_iterator(
                 ::gadjid::LoadError::NotAcyclic => bail!(err),
             },
         },
+        // we have a col-to-row matrix
         false => match PDAG::try_from_col_major(EdgelistIterator::into_column_major_edgelist(
             iterator, graph_size,
         )) {

--- a/gadjid_python/src/lib.rs
+++ b/gadjid_python/src/lib.rs
@@ -104,11 +104,7 @@ pub fn oset_aid(g_true: &PyAny, g_guess: &PyAny, edge_direction: &str) -> PyResu
 
 /// Parent Adjustment Identification Distance between two DAG / CPDAG adjacency matrices (sparse or dense)
 #[pyfunction]
-pub fn parent_aid(
-    g_true: &PyAny,
-    g_guess: &PyAny,
-    edge_direction: &str,
-) -> PyResult<(f64, usize)> {
+pub fn parent_aid(g_true: &PyAny, g_guess: &PyAny, edge_direction: &str) -> PyResult<(f64, usize)> {
     let row_to_col = edge_direction_is_row_to_col(edge_direction)?;
     let graph_truth = graph_from_pyobject(g_true, row_to_col)?;
     let graph_guess = graph_from_pyobject(g_guess, row_to_col)?;
@@ -128,11 +124,7 @@ pub fn shd(g_true: &PyAny, g_guess: &PyAny, edge_direction: &str) -> PyResult<(f
 
 /// Structural Identification Distance between two DAG adjacency matrices (sparse or dense)
 #[pyfunction]
-pub fn sid(
-    g_true: &PyAny,
-    g_guess: &PyAny,
-    edge_direction: &str,
-) -> anyhow::Result<(f64, usize)> {
+pub fn sid(g_true: &PyAny, g_guess: &PyAny, edge_direction: &str) -> anyhow::Result<(f64, usize)> {
     let row_to_col = edge_direction_is_row_to_col(edge_direction)?;
     let dag_truth = graph_from_pyobject(g_true, row_to_col)?;
     let dag_guess = graph_from_pyobject(g_guess, row_to_col)?;

--- a/gadjid_python/src/lib.rs
+++ b/gadjid_python/src/lib.rs
@@ -51,8 +51,8 @@ use scipy_sparse_handler::try_from as try_from_sparse;
 ///     [0, 0, 0, 0, 0]
 /// ], dtype=np.int8)
 ///
-/// print(ancestor_aid(Gtrue, Gguess))
-/// print(shd(Gtrue, Gguess))
+/// print(ancestor_aid(Gtrue, Gguess, edge_direction="from row to col"))
+/// print(shd(Gtrue, Gguess, edge_direction="from row to col"))
 /// ```
 #[pymodule]
 fn gadjid(_py: Python, m: &PyModule) -> PyResult<()> {

--- a/gadjid_python/src/lib.rs
+++ b/gadjid_python/src/lib.rs
@@ -36,12 +36,12 @@ one of the two entries is sufficient to code an undirected edge).
 
 An adjacency matrix for a DAG may only contain 0s and 1s.
 An adjacency matrix for a CPDAG may only contain 0s, 1s and 2s.
-DAG and CPDAG inputs are validated for acyclicity. 
-However, for CPDAG inputs, __the user needs to ensure the adjacency 
+DAG and CPDAG inputs are validated for acyclicity.
+However, for CPDAG inputs, __the user needs to ensure the adjacency
 matrix indeed codes a valid CPDAG (instead of just a PDAG)__.
 Example:
 ```python
-import 
+import
 from gadjid import example, ancestor_aid, oset_aid, parent_aid, shd
 import numpy as np
 

--- a/gadjid_python/src/lib.rs
+++ b/gadjid_python/src/lib.rs
@@ -51,8 +51,8 @@ use scipy_sparse_handler::try_from as try_from_sparse;
 ///     [0, 0, 0, 0, 0]
 /// ], dtype=np.int8)
 ///
-/// print(ancestor_aid(Gtrue, Gguess, edge_direction="from row to col"))
-/// print(shd(Gtrue, Gguess, edge_direction="from row to col"))
+/// print(ancestor_aid(Gtrue, Gguess, edge_direction="from row to column"))
+/// print(shd(Gtrue, Gguess, edge_direction="from row to column"))
 /// ```
 #[pymodule]
 fn gadjid(_py: Python, m: &PyModule) -> PyResult<()> {
@@ -64,8 +64,8 @@ fn gadjid(_py: Python, m: &PyModule) -> PyResult<()> {
     Ok(())
 }
 
-const ROW_TO_COL: &str = "from row to col";
-const COL_TO_ROW: &str = "from col to row";
+const ROW_TO_COL: &str = "from row to column";
+const COL_TO_ROW: &str = "from column to row";
 
 fn edge_direction_is_row_to_col(edge_direction: &str) -> PyResult<bool> {
     match edge_direction {

--- a/gadjid_python/src/lib.rs
+++ b/gadjid_python/src/lib.rs
@@ -33,18 +33,22 @@ use scipy_sparse_handler::try_from as try_from_sparse;
 /// for either setting of `edge_direction`,
 /// a `2` in row `r` and column `c` codes an undirected edge `r – t`
 /// (an additional `2` in row `c` and column `r` is ignored;
-/// only one of the two entries is required to code an undirected edge).
-/// An adjacency matrix for a DAG may only contain 0s and 1s;
-/// DAG inputs are validated for acyclicity.
-/// An adjacency matrix for a CPDAG may only contain 0s, 1s, and 2s;
-/// CPDAG inputs are not validated and __the user needs to ensure the adjacency matrix
-/// indeed codes a valid CPDAG (instead of just a PDAG)__.
+/// one of the two entries is sufficient to code an undirected edge).
+
+/// An adjacency matrix for a DAG may only contain 0s and 1s.
+/// An adjacency matrix for a CPDAG may only contain 0s, 1s and 2s.
+/// DAG and CPDAG inputs are validated for acyclicity. 
+/// However, for CPDAG inputs, __the user needs to ensure the adjacency 
+/// matrix indeed codes a valid CPDAG (instead of just a PDAG)__.
 ///
 /// Example:
 ///
 /// ```python
+/// import gadjid
 /// from gadjid import example, ancestor_aid, oset_aid, parent_aid, shd
 /// import numpy as np
+/// 
+/// help(gadjid)
 ///
 /// example.run_parent_aid()
 ///

--- a/gadjid_python/src/lib.rs
+++ b/gadjid_python/src/lib.rs
@@ -67,7 +67,7 @@ fn gadjid(_py: Python, m: &PyModule) -> PyResult<()> {
 const ROW_TO_COL: &str = "from row to col";
 const COL_TO_ROW: &str = "from col to row";
 
-fn edge_direction_semantics_is_row_to_col(edge_direction: &str) -> PyResult<bool> {
+fn edge_direction_is_row_to_col(edge_direction: &str) -> PyResult<bool> {
     match edge_direction {
         ROW_TO_COL => Ok(true),
         COL_TO_ROW => Ok(false),
@@ -83,9 +83,9 @@ fn edge_direction_semantics_is_row_to_col(edge_direction: &str) -> PyResult<bool
 pub fn ancestor_aid(
     g_true: &PyAny,
     g_guess: &PyAny,
-    edge_semantics: &str,
+    edge_direction: &str,
 ) -> PyResult<(f64, usize)> {
-    let row_to_col = edge_direction_semantics_is_row_to_col(edge_semantics)?;
+    let row_to_col = edge_direction_is_row_to_col(edge_direction)?;
     let graph_truth = graph_from_pyobject(g_true, row_to_col)?;
     let graph_guess = graph_from_pyobject(g_guess, row_to_col)?;
     let (normalized_distance, n_errors) = rust_ancestor_aid(&graph_truth, &graph_guess);
@@ -94,8 +94,8 @@ pub fn ancestor_aid(
 
 /// Optimal Adjustment Identification Distance between two DAG / CPDAG adjacency matrices (sparse or dense)
 #[pyfunction]
-pub fn oset_aid(g_true: &PyAny, g_guess: &PyAny, edge_semantics: &str) -> PyResult<(f64, usize)> {
-    let row_to_col = edge_direction_semantics_is_row_to_col(edge_semantics)?;
+pub fn oset_aid(g_true: &PyAny, g_guess: &PyAny, edge_direction: &str) -> PyResult<(f64, usize)> {
+    let row_to_col = edge_direction_is_row_to_col(edge_direction)?;
     let graph_truth = graph_from_pyobject(g_true, row_to_col)?;
     let graph_guess = graph_from_pyobject(g_guess, row_to_col)?;
     let (normalized_distance, n_errors) = rust_oset_aid(&graph_truth, &graph_guess);
@@ -107,9 +107,9 @@ pub fn oset_aid(g_true: &PyAny, g_guess: &PyAny, edge_semantics: &str) -> PyResu
 pub fn parent_aid(
     g_true: &PyAny,
     g_guess: &PyAny,
-    edge_semantics: &str,
+    edge_direction: &str,
 ) -> PyResult<(f64, usize)> {
-    let row_to_col = edge_direction_semantics_is_row_to_col(edge_semantics)?;
+    let row_to_col = edge_direction_is_row_to_col(edge_direction)?;
     let graph_truth = graph_from_pyobject(g_true, row_to_col)?;
     let graph_guess = graph_from_pyobject(g_guess, row_to_col)?;
     let (normalized_distance, n_errors) = rust_parent_aid(&graph_truth, &graph_guess);
@@ -118,8 +118,8 @@ pub fn parent_aid(
 
 /// Structural Hamming Distance between two DAG / CPDAG adjacency matrices (sparse or dense)
 #[pyfunction]
-pub fn shd(g_true: &PyAny, g_guess: &PyAny, edge_semantics: &str) -> PyResult<(f64, usize)> {
-    let row_to_col = edge_direction_semantics_is_row_to_col(edge_semantics)?;
+pub fn shd(g_true: &PyAny, g_guess: &PyAny, edge_direction: &str) -> PyResult<(f64, usize)> {
+    let row_to_col = edge_direction_is_row_to_col(edge_direction)?;
     let graph_truth = graph_from_pyobject(g_true, row_to_col)?;
     let graph_guess = graph_from_pyobject(g_guess, row_to_col)?;
     let (normalized_distance, n_errors) = rust_shd(&graph_truth, &graph_guess);
@@ -131,9 +131,9 @@ pub fn shd(g_true: &PyAny, g_guess: &PyAny, edge_semantics: &str) -> PyResult<(f
 pub fn sid(
     g_true: &PyAny,
     g_guess: &PyAny,
-    edge_semantics: &str,
+    edge_direction: &str,
 ) -> anyhow::Result<(f64, usize)> {
-    let row_to_col = edge_direction_semantics_is_row_to_col(edge_semantics)?;
+    let row_to_col = edge_direction_is_row_to_col(edge_direction)?;
     let dag_truth = graph_from_pyobject(g_true, row_to_col)?;
     let dag_guess = graph_from_pyobject(g_guess, row_to_col)?;
     let (normalized_distance, n_errors) = rust_sid(&dag_truth, &dag_guess)?;

--- a/gadjid_python/src/lib.rs
+++ b/gadjid_python/src/lib.rs
@@ -64,8 +64,8 @@ fn gadjid(_py: Python, m: &PyModule) -> PyResult<()> {
     Ok(())
 }
 
-const ROW_TO_COL: &str = "row->col";
-const COL_TO_ROW: &str = "col->row";
+const ROW_TO_COL: &str = "from row to col";
+const COL_TO_ROW: &str = "from col to row";
 
 fn edge_direction_semantics_is_row_to_col(edge_direction: &str) -> PyResult<bool> {
     match edge_direction {

--- a/gadjid_python/src/lib.rs
+++ b/gadjid_python/src/lib.rs
@@ -19,57 +19,52 @@ use ::gadjid::PDAG;
 use numpy_ndarray_handler::try_from as try_from_dense;
 use scipy_sparse_handler::try_from as try_from_sparse;
 
-/// Adjustment Identification Distance: A 𝚐𝚊𝚍𝚓𝚒𝚍 for Causal Structure Learning
-///
-/// For details, see the arXiv preprint at https://doi.org/10.48550/arXiv.2402.08616
-/// The source code is available at https://github.com/CausalDisco/gadjid
-///
-/// Adjacency matrices are accepted as either int8 numpy ndarrays
-/// or int8 scipy sparse matrices in CSR or CSC format.
-/// If `edge_direction="from row to column"`, then
-/// a `1` in row `r` and column `c` codes a directed edge `r → c`;
-/// if `edge_direction="from column to row"`, then
-/// a `1` in row `r` and column `c` codes a directed edge `c → r`;
-/// for either setting of `edge_direction`,
-/// a `2` in row `r` and column `c` codes an undirected edge `r – t`
-/// (an additional `2` in row `c` and column `r` is ignored;
-/// one of the two entries is sufficient to code an undirected edge).
+/**
+Adjustment Identification Distance: A 𝚐𝚊𝚍𝚓𝚒𝚍 for Causal Structure Learning
+For details, see the arXiv preprint at https://doi.org/10.48550/arXiv.2402.08616
+The source code is available at https://github.com/CausalDisco/gadjid
+Adjacency matrices are accepted as either int8 numpy ndarrays
+or int8 scipy sparse matrices in CSR or CSC format.
+If `edge_direction="from row to column"`, then
+a `1` in row `r` and column `c` codes a directed edge `r → c`;
+if `edge_direction="from column to row"`, then
+a `1` in row `r` and column `c` codes a directed edge `c → r`;
+for either setting of `edge_direction`,
+a `2` in row `r` and column `c` codes an undirected edge `r – t`
+(an additional `2` in row `c` and column `r` is ignored;
+one of the two entries is sufficient to code an undirected edge).
 
-/// An adjacency matrix for a DAG may only contain 0s and 1s.
-/// An adjacency matrix for a CPDAG may only contain 0s, 1s and 2s.
-/// DAG and CPDAG inputs are validated for acyclicity. 
-/// However, for CPDAG inputs, __the user needs to ensure the adjacency 
-/// matrix indeed codes a valid CPDAG (instead of just a PDAG)__.
-///
-/// Example:
-///
-/// ```python
-/// import gadjid
-/// from gadjid import example, ancestor_aid, oset_aid, parent_aid, shd
-/// import numpy as np
-/// 
-/// help(gadjid)
-///
-/// example.run_parent_aid()
-///
-/// Gtrue = np.array([
-///     [0, 1, 1, 1, 1],
-///     [0, 0, 1, 1, 1],
-///     [0, 0, 0, 0, 0],
-///     [0, 0, 0, 0, 0],
-///     [0, 0, 0, 0, 0]
-/// ], dtype=np.int8)
-/// Gguess = np.array([
-///     [0, 0, 1, 1, 1],
-///     [1, 0, 1, 1, 1],
-///     [0, 0, 0, 0, 0],
-///     [0, 0, 0, 0, 0],
-///     [0, 0, 0, 0, 0]
-/// ], dtype=np.int8)
-///
-/// print(ancestor_aid(Gtrue, Gguess, edge_direction="from row to column"))
-/// print(shd(Gtrue, Gguess))
-/// ```
+An adjacency matrix for a DAG may only contain 0s and 1s.
+An adjacency matrix for a CPDAG may only contain 0s, 1s and 2s.
+DAG and CPDAG inputs are validated for acyclicity. 
+However, for CPDAG inputs, __the user needs to ensure the adjacency 
+matrix indeed codes a valid CPDAG (instead of just a PDAG)__.
+Example:
+```python
+import 
+from gadjid import example, ancestor_aid, oset_aid, parent_aid, shd
+import numpy as np
+
+help(gadjid)
+example.run_parent_aid()
+Gtrue = np.array([
+    [0, 1, 1, 1, 1],
+    [0, 0, 1, 1, 1],
+    [0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0]
+], dtype=np.int8)
+Gguess = np.array([
+    [0, 0, 1, 1, 1],
+    [1, 0, 1, 1, 1],
+    [0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0]
+], dtype=np.int8)
+print(ancestor_aid(Gtrue, Gguess, edge_direction="from row to column"))
+print(shd(Gtrue, Gguess))
+```
+*/
 #[pymodule]
 fn gadjid(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(crate::ancestor_aid, m)?)?;

--- a/gadjid_python/src/lib.rs
+++ b/gadjid_python/src/lib.rs
@@ -21,8 +21,10 @@ use scipy_sparse_handler::try_from as try_from_sparse;
 
 /**
 Adjustment Identification Distance: A 𝚐𝚊𝚍𝚓𝚒𝚍 for Causal Structure Learning
+
 For details, see the arXiv preprint at https://doi.org/10.48550/arXiv.2402.08616
 The source code is available at https://github.com/CausalDisco/gadjid
+
 Adjacency matrices are accepted as either int8 numpy ndarrays
 or int8 scipy sparse matrices in CSR or CSC format.
 If `edge_direction="from row to column"`, then
@@ -30,7 +32,7 @@ a `1` in row `r` and column `c` codes a directed edge `r → c`;
 if `edge_direction="from column to row"`, then
 a `1` in row `r` and column `c` codes a directed edge `c → r`;
 for either setting of `edge_direction`,
-a `2` in row `r` and column `c` codes an undirected edge `r – t`
+a `2` in row `r` and column `c` codes an undirected edge `r – c`
 (an additional `2` in row `c` and column `r` is ignored;
 one of the two entries is sufficient to code an undirected edge).
 
@@ -39,14 +41,18 @@ An adjacency matrix for a CPDAG may only contain 0s, 1s and 2s.
 DAG and CPDAG inputs are validated for acyclicity.
 However, for CPDAG inputs, __the user needs to ensure the adjacency
 matrix indeed codes a valid CPDAG (instead of just a PDAG)__.
+
 Example:
+
 ```python
-import
+import gadjid
 from gadjid import example, ancestor_aid, oset_aid, parent_aid, shd
 import numpy as np
 
 help(gadjid)
+
 example.run_parent_aid()
+
 Gtrue = np.array([
     [0, 1, 1, 1, 1],
     [0, 0, 1, 1, 1],
@@ -61,6 +67,7 @@ Gguess = np.array([
     [0, 0, 0, 0, 0],
     [0, 0, 0, 0, 0]
 ], dtype=np.int8)
+
 print(ancestor_aid(Gtrue, Gguess, edge_direction="from row to column"))
 print(shd(Gtrue, Gguess))
 ```

--- a/gadjid_python/src/lib.rs
+++ b/gadjid_python/src/lib.rs
@@ -113,6 +113,8 @@ pub fn parent_aid(g_true: &PyAny, g_guess: &PyAny, edge_direction: &str) -> PyRe
 }
 
 /// Structural Hamming Distance between two DAG / CPDAG adjacency matrices (sparse or dense)
+/// Does not take `edge_direction` argument, because SHD only considers the adjacency matrix,
+/// irrespective of the edge direction interpretation.
 #[pyfunction]
 pub fn shd(g_true: &PyAny, g_guess: &PyAny) -> PyResult<(f64, usize)> {
     // set row_to_col variable to 'true', but it doesn't matter

--- a/gadjid_python/src/lib.rs
+++ b/gadjid_python/src/lib.rs
@@ -84,7 +84,7 @@ fn edge_direction_is_row_to_col(edge_direction: &str) -> PyResult<bool> {
         ROW_TO_COL => Ok(true),
         COL_TO_ROW => Ok(false),
         _ => Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
-            "edge_direction string argument must be either '{}' or '{}'",
+            r#"edge_direction string argument must be either "{}" or "{}""#,
             ROW_TO_COL, COL_TO_ROW
         ))),
     }

--- a/gadjid_python/src/numpy_ndarray_handler.rs
+++ b/gadjid_python/src/numpy_ndarray_handler.rs
@@ -8,7 +8,7 @@ use pyo3::PyAny;
 use crate::graph_from_iterator;
 
 /// Load a PDAG from a numpy ndarray
-pub fn try_from(ob: &PyAny) -> anyhow::Result<PDAG> {
+pub fn try_from(ob: &PyAny, row_to_col: bool) -> anyhow::Result<PDAG> {
     let ndarray = ob.extract::<PyReadonlyArray2<i8>>()?;
     let shape = ndarray.shape();
     let graph_size = shape[0];
@@ -16,22 +16,30 @@ pub fn try_from(ob: &PyAny) -> anyhow::Result<PDAG> {
     anyhow::ensure!(graph_size > 0, "Matrix must be non-empty");
 
     // determine iteration order
-    let row_major = ndarray.is_c_contiguous();
+    let row_major_iteration = ndarray.is_c_contiguous();
+    // load as row-major if it's in row-major order and we want to interpret it as row_to_col,
+    // or if it's in column-major order and we want to interpret it as col_to_row (so transpose by interpreting as row-major)
+    let interpret_as_row_major = row_to_col == row_major_iteration;
     // check if array is contiguous and then get slice
     if let Ok(slice) = ndarray.as_slice() {
-        graph_from_slice(slice, row_major, graph_size)
+        graph_from_slice(slice, interpret_as_row_major, graph_size)
     }
     // otherwise load from view
     else {
-        // we will load views as if they are row-major iterators,
+        // views are row-major iterators,
         // as we use .indexed_iter() which is row-major.
         // https://docs.rs/ndarray/latest/ndarray/struct.ArrayBase.html#method.indexed_iter
-        graph_from_view(ndarray.as_array(), true, graph_size)
+        // so the load order is solely determined by the 'is_row_to_col' flag
+        graph_from_view(ndarray.as_array(), row_to_col, graph_size)
     }
 }
 
 /// Load a PDAG from an slice of i8s
-fn graph_from_slice(slice: &[i8], row_major: bool, graph_size: usize) -> anyhow::Result<PDAG> {
+fn graph_from_slice(
+    slice: &[i8],
+    interpret_as_row_major: bool,
+    graph_size: usize,
+) -> anyhow::Result<PDAG> {
     let iterator = slice.iter().enumerate().map(move |(ind, val)| {
         (
             ind / graph_size,
@@ -40,18 +48,18 @@ fn graph_from_slice(slice: &[i8], row_major: bool, graph_size: usize) -> anyhow:
         )
     });
 
-    graph_from_iterator(iterator, row_major, graph_size)
+    graph_from_iterator(iterator, interpret_as_row_major, graph_size)
 }
 
 /// Load a PDAG from a numpy ndarray view
 fn graph_from_view(
     view: ArrayView2<i8>,
-    row_major: bool,
+    row_to_col: bool,
     graph_size: usize,
 ) -> anyhow::Result<PDAG> {
     let iterator = view
         .indexed_iter()
         .map(move |((row, col), val)| (row, col, *val));
 
-    graph_from_iterator(iterator, row_major, graph_size)
+    graph_from_iterator(iterator, row_to_col, graph_size)
 }

--- a/gadjid_python/tests/test_DAG_loading_for_all_formats.py
+++ b/gadjid_python/tests/test_DAG_loading_for_all_formats.py
@@ -22,12 +22,12 @@ COL_TO_ROW = "from col to row"
 
 def test_edge_direction_argument():
     exps = 10
-    for _exp in range(exps):
+    for exp in range(exps):
         size = 10
 
         # make 2 random dags:
-        truth_dag = make_dag(size, 0.5)
-        guess_dag = make_dag(size, 0.5)
+        truth_dag = make_dag(size, 0.5, exp)
+        guess_dag = make_dag(size, 0.5, exp + exps)
 
         # for all functions that take an edge_direction argument, check that
         # the result is the same for both edge directions

--- a/gadjid_python/tests/test_DAG_loading_for_all_formats.py
+++ b/gadjid_python/tests/test_DAG_loading_for_all_formats.py
@@ -2,7 +2,7 @@
 import numpy as np
 import scipy
 
-import gadjid as aid
+import gadjid
 
 
 def make_dag(size, density, seed) -> np.ndarray:
@@ -46,7 +46,8 @@ def test_DAG_loading_for_all_formats():
 
         last_result = None
         for i, matrix in enumerate(matrices):
-            current_result = aid.shd(matrix, matrices[0])
+            current_result = gadjid.shd(
+                matrix, matrices[0], edge_direction="from row to col")
             assert (
                 last_result is None or last_result == current_result
             ), f"failed for {names[i]}"

--- a/gadjid_python/tests/test_DAG_loading_for_all_formats.py
+++ b/gadjid_python/tests/test_DAG_loading_for_all_formats.py
@@ -47,7 +47,7 @@ def test_DAG_loading_for_all_formats():
         last_result = None
         for i, matrix in enumerate(matrices):
             current_result = gadjid.shd(
-                matrix, matrices[0], edge_direction="from row to col")
+                matrix, matrices[0])
             assert (
                 last_result is None or last_result == current_result
             ), f"failed for {names[i]}"

--- a/gadjid_python/tests/test_DAG_loading_for_all_formats.py
+++ b/gadjid_python/tests/test_DAG_loading_for_all_formats.py
@@ -8,11 +8,47 @@ import gadjid
 def make_dag(size, density, seed) -> np.ndarray:
     np.random.seed(seed)
     dense: np.ndarray = np.random.binomial(
-        1, density, size=(size, size)).astype(np.int8)
+        1, density, size=(size, size)
+    ).astype(np.int8)
     # fill lower triangle+diagonal with zeros
     dense = np.triu(dense, 1)
     perm = np.random.permutation(size)
     return dense[perm, :][:, perm]
+
+
+ROW_TO_COL = "from row to col"
+COL_TO_ROW = "from col to row"
+
+
+def test_edge_direction_argument():
+    exps = 10
+    for _exp in range(exps):
+        size = 10
+
+        # make 2 random dags:
+        truth_dag = make_dag(size, 0.5)
+        guess_dag = make_dag(size, 0.5)
+
+        # for all functions that take an edge_direction argument, check that
+        # the result is the same for both edge directions
+        assert gadjid.sid(
+            truth_dag, guess_dag, edge_direction=ROW_TO_COL
+        ) == gadjid.sid(truth_dag.T, guess_dag.T, edge_direction=COL_TO_ROW)
+        assert gadjid.parent_aid(
+            truth_dag, guess_dag, edge_direction=ROW_TO_COL
+        ) == gadjid.parent_aid(
+            truth_dag.T, guess_dag.T, edge_direction=COL_TO_ROW
+        )
+        assert gadjid.ancestor_aid(
+            truth_dag, guess_dag, edge_direction=ROW_TO_COL
+        ) == gadjid.ancestor_aid(
+            truth_dag.T, guess_dag.T, edge_direction=COL_TO_ROW
+        )
+        assert gadjid.oset_aid(
+            truth_dag, guess_dag, edge_direction=ROW_TO_COL
+        ) == gadjid.oset_aid(
+            truth_dag.T, guess_dag.T, edge_direction=COL_TO_ROW
+        )
 
 
 def test_DAG_loading_for_all_formats():
@@ -46,8 +82,7 @@ def test_DAG_loading_for_all_formats():
 
         last_result = None
         for i, matrix in enumerate(matrices):
-            current_result = gadjid.shd(
-                matrix, matrices[0])
+            current_result = gadjid.shd(matrix, matrices[0])
             assert (
                 last_result is None or last_result == current_result
             ), f"failed for {names[i]}"
@@ -55,4 +90,6 @@ def test_DAG_loading_for_all_formats():
 
 
 if __name__ == "__main__":
+    test_edge_direction_argument()
     test_DAG_loading_for_all_formats()
+    print("all tests passed")

--- a/gadjid_python/tests/test_DAG_loading_for_all_formats.py
+++ b/gadjid_python/tests/test_DAG_loading_for_all_formats.py
@@ -16,8 +16,8 @@ def make_dag(size, density, seed) -> np.ndarray:
     return dense[perm, :][:, perm]
 
 
-ROW_TO_COL = "from row to col"
-COL_TO_ROW = "from col to row"
+ROW_TO_COL = "from row to column"
+COL_TO_ROW = "from column to row"
 
 
 def test_edge_direction_argument():

--- a/gadjid_python/tests/test_parent_AID_against_R_SID.py
+++ b/gadjid_python/tests/test_parent_AID_against_R_SID.py
@@ -33,7 +33,7 @@ def test_parent_AID_against_R_SID():
         guess_name = int(guess_name)
         Gtrue = load_trlpt(true_name)
         Gguess = load_trlpt(guess_name)
-        sid = parent_aid(Gtrue, Gguess, edge_direction="from row to col")
+        sid = parent_aid(Gtrue, Gguess, edge_direction="from row to column")
         assert sid[1] == int(rsid), (
             f"failed for sid({true_name}, {guess_name}):"
             f" {sid[1]} vs {int(rsid)}"

--- a/gadjid_python/tests/test_parent_AID_against_R_SID.py
+++ b/gadjid_python/tests/test_parent_AID_against_R_SID.py
@@ -33,7 +33,7 @@ def test_parent_AID_against_R_SID():
         guess_name = int(guess_name)
         Gtrue = load_trlpt(true_name)
         Gguess = load_trlpt(guess_name)
-        sid = parent_aid(Gtrue, Gguess)
+        sid = parent_aid(Gtrue, Gguess, edge_direction="from row to col")
         assert sid[1] == int(rsid), (
             f"failed for sid({true_name}, {guess_name}):"
             f" {sid[1]} vs {int(rsid)}"


### PR DESCRIPTION
Currently there is an implicit assumption that an adjacency matrix
```text
M = 
[[0, 1], 
 [0, 0]]
```
encodes the graph `0 -> 1`. 

This is the `row->col` interpretation: 

`M[X, Y] = 1` $\iff$ `X -> Y`.


The `col->row` interpretation is the opposite: 

`M[X, Y] = 1` $\iff$ `X <- Y`.

Undirected edges are unaffected by this, as 

 `M[X, Y] = 2` $\vee$ `M[Y, X] = 2`  $\iff$ `X -- Y`.

This PR forces the users of the gadjid_python library to supply either the string `"row->col"` or `"col->row"` when passing an adjacency matrix in `scipy.sparse` or `np.ndarray` format.