### PR TITLE
Oset in insta snapshots

### DIFF
--- a/gadjid/src/graph_operations/oset_aid.rs
+++ b/gadjid/src/graph_operations/oset_aid.rs
@@ -13,7 +13,7 @@ use crate::{
 
 /// This oset function takes in a precomputed t_descendants set.
 /// Returns the optimal adjustment set of the provided treatments.
-pub fn optimal_adjustment_set(
+pub fn optimal_adjustment_set_given_descendants(
     dag: &PDAG,
     treatments: &[usize],
     responses: &[usize],
@@ -71,8 +71,12 @@ pub fn oset_aid(truth: &PDAG, guess: &PDAG) -> (f64, usize) {
                     // if they agree on amenability and y is amenable, we need to find the adjustment set
                     else if !y_nam_in_guess {
                         // this oset function uses the precomputed t_desc_in_guess
-                        let o_set_adjustment =
-                            optimal_adjustment_set(guess, &[treatment], &[y], &t_desc_in_guess);
+                        let o_set_adjustment = optimal_adjustment_set_given_descendants(
+                            guess,
+                            &[treatment],
+                            &[y],
+                            &t_desc_in_guess,
+                        );
 
                         // (because the VAS is not valid, by blocking too much or too little)
                         if get_invalidly_un_blocked(truth, &[treatment], &o_set_adjustment)
@@ -98,13 +102,23 @@ pub fn oset_aid(truth: &PDAG, guess: &PDAG) -> (f64, usize) {
 }
 
 #[cfg(test)]
+pub fn optimal_adjustment_set(
+    dag: &PDAG,
+    treatments: &[usize],
+    responses: &[usize],
+) -> FxHashSet<usize> {
+    let t_descendants = crate::graph_operations::get_descendants(dag, treatments.iter());
+    optimal_adjustment_set_given_descendants(dag, treatments, responses, &t_descendants)
+}
+
+#[cfg(test)]
 mod test {
     use rand::SeedableRng;
     use rustc_hash::FxHashSet;
 
     use crate::PDAG;
 
-    use super::oset_aid;
+    use super::{optimal_adjustment_set, oset_aid};
 
     #[test]
     fn property_equal_dags_zero_distance() {
@@ -133,15 +147,6 @@ mod test {
                 oset_aid(&dag1, &dag2);
             }
         }
-    }
-
-    fn optimal_adjustment_set(
-        dag: &PDAG,
-        treatments: &[usize],
-        responses: &[usize],
-    ) -> FxHashSet<usize> {
-        let t_descendants = crate::graph_operations::get_descendants(dag, treatments.iter());
-        super::optimal_adjustment_set(dag, treatments, responses, &t_descendants)
     }
 
     #[test]

--- a/gadjid/src/graph_operations/oset_aid.rs
+++ b/gadjid/src/graph_operations/oset_aid.rs
@@ -78,7 +78,7 @@ pub fn oset_aid(truth: &PDAG, guess: &PDAG) -> (f64, usize) {
                             &t_desc_in_guess,
                         );
 
-                        // (because the VAS is not valid, by blocking too much or too little)
+                        // if the o-set from the guess graph is not valid in the truth graph (by blocking too much or too little)
                         if get_invalidly_un_blocked(truth, &[treatment], &o_set_adjustment)
                             .contains(&y)
                         {

--- a/gadjid/src/lib.rs
+++ b/gadjid/src/lib.rs
@@ -141,15 +141,7 @@ mod test {
         let mut random_z = indices[1 + t_size..1 + t_size + random_z_size as usize].to_vec();
         random_z.sort();
 
-        let oset_for_t_onto_y_in_g_guess = {
-            let t_descendants = gensearch(
-                &g_guess,
-                crate::graph_operations::ruletables::Descendants {},
-                t.iter(),
-                true,
-            );
-            optimal_adjustment_set(&g_guess, &t, &[y], &t_descendants)
-        };
+        let oset_for_t_onto_y_in_g_guess = optimal_adjustment_set(&g_guess, &t, &[y]);
 
         Testcase {
             g_true: g_true_name.to_string(),

--- a/gadjid/src/lib.rs
+++ b/gadjid/src/lib.rs
@@ -146,7 +146,7 @@ mod test {
                 &g_guess,
                 crate::graph_operations::ruletables::Descendants {},
                 t.iter(),
-                false,
+                true,
             );
             optimal_adjustment_set(&g_guess, &t, &[y], &t_descendants)
         };

--- a/gadjid/src/snapshots/gadjid__test__large-CPDAG20-vs-CPDAG21.snap
+++ b/gadjid/src/snapshots/gadjid__test__large-CPDAG20-vs-CPDAG21.snap
@@ -260,16 +260,11 @@ proper_ancestors_of_y_in_g_guess_wrt_t:
   - 71
 oset_for_t_onto_y_in_g_guess:
   - 0
-  - 1
-  - 2
   - 3
   - 4
-  - 7
   - 8
   - 9
-  - 12
   - 15
-  - 17
 not_validly_adjusted_for_in_g_guess_by_parents_of_t:
   - 0
   - 1
@@ -368,20 +363,15 @@ not_validly_adjusted_for_in_g_guess_by_parents_of_t:
   - 99
 not_validly_adjusted_for_in_g_guess_by_oset_for_t_onto_y:
   - 0
-  - 1
-  - 2
   - 3
   - 4
   - 5
-  - 7
   - 8
   - 9
   - 10
-  - 12
   - 13
   - 14
   - 15
-  - 17
   - 18
   - 20
   - 21

--- a/gadjid/src/snapshots/gadjid__test__large-CPDAG21-vs-CPDAG22.snap
+++ b/gadjid/src/snapshots/gadjid__test__large-CPDAG21-vs-CPDAG22.snap
@@ -276,17 +276,10 @@ proper_ancestors_of_y_in_g_guess_wrt_t:
   - 67
   - 69
 oset_for_t_onto_y_in_g_guess:
-  - 0
   - 1
   - 2
-  - 3
   - 4
-  - 7
-  - 8
-  - 9
-  - 12
   - 15
-  - 17
 not_validly_adjusted_for_in_g_guess_by_parents_of_t:
   - 0
   - 1
@@ -384,20 +377,13 @@ not_validly_adjusted_for_in_g_guess_by_parents_of_t:
   - 97
   - 99
 not_validly_adjusted_for_in_g_guess_by_oset_for_t_onto_y:
-  - 0
   - 1
   - 2
-  - 3
   - 4
   - 5
   - 6
-  - 7
-  - 8
-  - 9
-  - 12
   - 15
   - 16
-  - 17
   - 18
   - 19
   - 20

--- a/gadjid/src/snapshots/gadjid__test__large-CPDAG22-vs-CPDAG23.snap
+++ b/gadjid/src/snapshots/gadjid__test__large-CPDAG22-vs-CPDAG23.snap
@@ -217,9 +217,7 @@ possible_descendants_of_t_in_g_guess:
 not_amenable_in_g_guess_wrt_t: []
 proper_ancestors_of_y_in_g_guess_wrt_t:
   - 21
-oset_for_t_onto_y_in_g_guess:
-  - 1
-  - 10
+oset_for_t_onto_y_in_g_guess: []
 not_validly_adjusted_for_in_g_guess_by_parents_of_t:
   - 0
   - 1
@@ -315,9 +313,7 @@ not_validly_adjusted_for_in_g_guess_by_parents_of_t:
   - 95
   - 96
 not_validly_adjusted_for_in_g_guess_by_oset_for_t_onto_y:
-  - 1
   - 6
-  - 10
   - 17
   - 21
   - 63

--- a/gadjid/src/snapshots/gadjid__test__large-CPDAG23-vs-CPDAG24.snap
+++ b/gadjid/src/snapshots/gadjid__test__large-CPDAG23-vs-CPDAG24.snap
@@ -224,19 +224,15 @@ proper_ancestors_of_y_in_g_guess_wrt_t:
   - 53
   - 62
 oset_for_t_onto_y_in_g_guess:
-  - 0
   - 1
   - 2
-  - 3
   - 5
-  - 6
   - 7
   - 8
   - 9
   - 10
   - 11
   - 12
-  - 13
   - 21
   - 23
 not_validly_adjusted_for_in_g_guess_by_parents_of_t:
@@ -334,19 +330,15 @@ not_validly_adjusted_for_in_g_guess_by_parents_of_t:
   - 97
   - 98
 not_validly_adjusted_for_in_g_guess_by_oset_for_t_onto_y:
-  - 0
   - 1
   - 2
-  - 3
   - 5
-  - 6
   - 7
   - 8
   - 9
   - 10
   - 11
   - 12
-  - 13
   - 14
   - 15
   - 16

--- a/gadjid/src/snapshots/gadjid__test__large-CPDAG24-vs-CPDAG25.snap
+++ b/gadjid/src/snapshots/gadjid__test__large-CPDAG24-vs-CPDAG25.snap
@@ -228,7 +228,6 @@ proper_ancestors_of_y_in_g_guess_wrt_t:
   - 27
 oset_for_t_onto_y_in_g_guess:
   - 7
-  - 9
 not_validly_adjusted_for_in_g_guess_by_parents_of_t:
   - 0
   - 1
@@ -327,7 +326,6 @@ not_validly_adjusted_for_in_g_guess_by_oset_for_t_onto_y:
   - 0
   - 2
   - 7
-  - 9
   - 27
   - 51
   - 59

--- a/gadjid/src/snapshots/gadjid__test__large-CPDAG25-vs-CPDAG26.snap
+++ b/gadjid/src/snapshots/gadjid__test__large-CPDAG25-vs-CPDAG26.snap
@@ -271,9 +271,6 @@ proper_ancestors_of_y_in_g_guess_wrt_t:
 oset_for_t_onto_y_in_g_guess:
   - 0
   - 1
-  - 2
-  - 3
-  - 4
 not_validly_adjusted_for_in_g_guess_by_parents_of_t:
   - 0
   - 1
@@ -375,9 +372,6 @@ not_validly_adjusted_for_in_g_guess_by_parents_of_t:
 not_validly_adjusted_for_in_g_guess_by_oset_for_t_onto_y:
   - 0
   - 1
-  - 2
-  - 3
-  - 4
   - 5
   - 8
   - 9

--- a/gadjid/src/snapshots/gadjid__test__large-CPDAG26-vs-CPDAG27.snap
+++ b/gadjid/src/snapshots/gadjid__test__large-CPDAG26-vs-CPDAG27.snap
@@ -233,9 +233,7 @@ not_amenable_in_g_guess_wrt_t:
 proper_ancestors_of_y_in_g_guess_wrt_t:
   - 3
   - 9
-oset_for_t_onto_y_in_g_guess:
-  - 0
-  - 1
+oset_for_t_onto_y_in_g_guess: []
 not_validly_adjusted_for_in_g_guess_by_parents_of_t:
   - 0
   - 1
@@ -335,8 +333,6 @@ not_validly_adjusted_for_in_g_guess_by_parents_of_t:
   - 96
   - 97
 not_validly_adjusted_for_in_g_guess_by_oset_for_t_onto_y:
-  - 0
-  - 1
   - 3
   - 9
   - 12

--- a/gadjid/src/snapshots/gadjid__test__large-CPDAG28-vs-CPDAG29.snap
+++ b/gadjid/src/snapshots/gadjid__test__large-CPDAG28-vs-CPDAG29.snap
@@ -236,7 +236,6 @@ oset_for_t_onto_y_in_g_guess:
   - 8
   - 9
   - 10
-  - 11
 not_validly_adjusted_for_in_g_guess_by_parents_of_t:
   - 0
   - 1
@@ -346,7 +345,6 @@ not_validly_adjusted_for_in_g_guess_by_oset_for_t_onto_y:
   - 8
   - 9
   - 10
-  - 11
   - 12
   - 13
   - 14

--- a/gadjid/src/snapshots/gadjid__test__large-CPDAG29-vs-CPDAG20.snap
+++ b/gadjid/src/snapshots/gadjid__test__large-CPDAG29-vs-CPDAG20.snap
@@ -250,13 +250,6 @@ proper_ancestors_of_y_in_g_guess_wrt_t:
 oset_for_t_onto_y_in_g_guess:
   - 0
   - 1
-  - 2
-  - 3
-  - 4
-  - 7
-  - 8
-  - 9
-  - 12
   - 15
 not_validly_adjusted_for_in_g_guess_by_parents_of_t:
   - 0
@@ -356,13 +349,6 @@ not_validly_adjusted_for_in_g_guess_by_parents_of_t:
 not_validly_adjusted_for_in_g_guess_by_oset_for_t_onto_y:
   - 0
   - 1
-  - 2
-  - 3
-  - 4
-  - 7
-  - 8
-  - 9
-  - 12
   - 15
   - 16
   - 19

--- a/gadjid/src/snapshots/gadjid__test__large-DAG20-vs-DAG21.snap
+++ b/gadjid/src/snapshots/gadjid__test__large-DAG20-vs-DAG21.snap
@@ -245,7 +245,6 @@ oset_for_t_onto_y_in_g_guess:
   - 6
   - 7
   - 8
-  - 9
   - 10
   - 11
   - 12
@@ -266,7 +265,6 @@ not_validly_adjusted_for_in_g_guess_by_oset_for_t_onto_y:
   - 6
   - 7
   - 8
-  - 9
   - 10
   - 11
   - 12

--- a/gadjid/src/snapshots/gadjid__test__large-DAG22-vs-DAG23.snap
+++ b/gadjid/src/snapshots/gadjid__test__large-DAG22-vs-DAG23.snap
@@ -215,15 +215,7 @@ proper_ancestors_of_y_in_g_guess_wrt_t:
   - 55
   - 76
 oset_for_t_onto_y_in_g_guess:
-  - 0
-  - 1
-  - 2
-  - 4
-  - 6
   - 7
-  - 10
-  - 13
-  - 23
 not_validly_adjusted_for_in_g_guess_by_parents_of_t:
   - 0
   - 1
@@ -319,20 +311,12 @@ not_validly_adjusted_for_in_g_guess_by_parents_of_t:
   - 95
   - 96
 not_validly_adjusted_for_in_g_guess_by_oset_for_t_onto_y:
-  - 0
-  - 1
-  - 2
-  - 4
-  - 6
   - 7
   - 8
-  - 10
   - 11
-  - 13
   - 15
   - 17
   - 21
-  - 23
   - 25
   - 26
   - 30

--- a/gadjid/src/snapshots/gadjid__test__large-DAG23-vs-DAG24.snap
+++ b/gadjid/src/snapshots/gadjid__test__large-DAG23-vs-DAG24.snap
@@ -167,15 +167,12 @@ oset_for_t_onto_y_in_g_guess:
   - 2
   - 3
   - 4
-  - 5
   - 6
   - 7
   - 9
   - 10
   - 13
   - 21
-  - 23
-  - 25
 not_validly_adjusted_for_in_g_guess_by_parents_of_t:
   - 0
   - 1
@@ -277,7 +274,6 @@ not_validly_adjusted_for_in_g_guess_by_oset_for_t_onto_y:
   - 2
   - 3
   - 4
-  - 5
   - 6
   - 7
   - 8
@@ -293,9 +289,7 @@ not_validly_adjusted_for_in_g_guess_by_oset_for_t_onto_y:
   - 18
   - 21
   - 22
-  - 23
   - 24
-  - 25
   - 26
   - 27
   - 30

--- a/gadjid/src/snapshots/gadjid__test__large-DAG24-vs-DAG25.snap
+++ b/gadjid/src/snapshots/gadjid__test__large-DAG24-vs-DAG25.snap
@@ -232,10 +232,8 @@ oset_for_t_onto_y_in_g_guess:
   - 3
   - 5
   - 6
-  - 8
   - 10
   - 13
-  - 21
   - 23
   - 25
 not_validly_adjusted_for_in_g_guess_by_parents_of_t:
@@ -340,14 +338,12 @@ not_validly_adjusted_for_in_g_guess_by_oset_for_t_onto_y:
   - 3
   - 5
   - 6
-  - 8
   - 10
   - 13
   - 14
   - 16
   - 17
   - 18
-  - 21
   - 22
   - 23
   - 25

--- a/gadjid/src/snapshots/gadjid__test__large-DAG25-vs-DAG26.snap
+++ b/gadjid/src/snapshots/gadjid__test__large-DAG25-vs-DAG26.snap
@@ -222,9 +222,7 @@ proper_ancestors_of_y_in_g_guess_wrt_t:
   - 59
   - 66
   - 78
-oset_for_t_onto_y_in_g_guess:
-  - 0
-  - 1
+oset_for_t_onto_y_in_g_guess: []
 not_validly_adjusted_for_in_g_guess_by_parents_of_t:
   - 0
   - 1
@@ -324,8 +322,6 @@ not_validly_adjusted_for_in_g_guess_by_parents_of_t:
   - 96
   - 97
 not_validly_adjusted_for_in_g_guess_by_oset_for_t_onto_y:
-  - 0
-  - 1
   - 7
   - 8
   - 10

--- a/gadjid/src/snapshots/gadjid__test__large-DAG26-vs-DAG27.snap
+++ b/gadjid/src/snapshots/gadjid__test__large-DAG26-vs-DAG27.snap
@@ -219,9 +219,7 @@ possible_descendants_of_t_in_g_guess:
 not_amenable_in_g_guess_wrt_t: []
 proper_ancestors_of_y_in_g_guess_wrt_t:
   - 3
-oset_for_t_onto_y_in_g_guess:
-  - 0
-  - 1
+oset_for_t_onto_y_in_g_guess: []
 not_validly_adjusted_for_in_g_guess_by_parents_of_t:
   - 0
   - 1
@@ -321,8 +319,6 @@ not_validly_adjusted_for_in_g_guess_by_parents_of_t:
   - 96
   - 97
 not_validly_adjusted_for_in_g_guess_by_oset_for_t_onto_y:
-  - 0
-  - 1
   - 3
   - 16
   - 38

--- a/gadjid/src/snapshots/gadjid__test__large-DAG27-vs-DAG28.snap
+++ b/gadjid/src/snapshots/gadjid__test__large-DAG27-vs-DAG28.snap
@@ -219,7 +219,6 @@ proper_ancestors_of_y_in_g_guess_wrt_t:
   - 48
 oset_for_t_onto_y_in_g_guess:
   - 0
-  - 1
   - 4
 not_validly_adjusted_for_in_g_guess_by_parents_of_t:
   - 0
@@ -322,7 +321,6 @@ not_validly_adjusted_for_in_g_guess_by_parents_of_t:
   - 99
 not_validly_adjusted_for_in_g_guess_by_oset_for_t_onto_y:
   - 0
-  - 1
   - 3
   - 4
   - 5

--- a/gadjid/src/snapshots/gadjid__test__large-DAG28-vs-DAG29.snap
+++ b/gadjid/src/snapshots/gadjid__test__large-DAG28-vs-DAG29.snap
@@ -211,8 +211,6 @@ proper_ancestors_of_y_in_g_guess_wrt_t:
   - 61
 oset_for_t_onto_y_in_g_guess:
   - 0
-  - 1
-  - 2
 not_validly_adjusted_for_in_g_guess_by_parents_of_t:
   - 0
   - 1
@@ -313,8 +311,6 @@ not_validly_adjusted_for_in_g_guess_by_parents_of_t:
   - 99
 not_validly_adjusted_for_in_g_guess_by_oset_for_t_onto_y:
   - 0
-  - 1
-  - 2
   - 3
   - 6
   - 7

--- a/gadjid/src/snapshots/gadjid__test__small-CPDAG12-vs-CPDAG13.snap
+++ b/gadjid/src/snapshots/gadjid__test__small-CPDAG12-vs-CPDAG13.snap
@@ -42,9 +42,7 @@ possible_descendants_of_t_in_g_guess:
 not_amenable_in_g_guess_wrt_t: []
 proper_ancestors_of_y_in_g_guess_wrt_t:
   - 2
-oset_for_t_onto_y_in_g_guess:
-  - 0
-  - 9
+oset_for_t_onto_y_in_g_guess: []
 not_validly_adjusted_for_in_g_guess_by_parents_of_t:
   - 2
   - 5
@@ -52,9 +50,7 @@ not_validly_adjusted_for_in_g_guess_by_parents_of_t:
   - 8
   - 9
 not_validly_adjusted_for_in_g_guess_by_oset_for_t_onto_y:
-  - 0
   - 2
-  - 9
 not_validly_adjusted_for_in_g_guess_by_empty_set:
   - 2
 not_validly_adjusted_for_in_g_guess_by_z:

--- a/gadjid/src/snapshots/gadjid__test__small-DAG11-vs-DAG12.snap
+++ b/gadjid/src/snapshots/gadjid__test__small-DAG11-vs-DAG12.snap
@@ -38,18 +38,14 @@ proper_ancestors_of_y_in_g_guess_wrt_t:
   - 7
 oset_for_t_onto_y_in_g_guess:
   - 2
-  - 3
   - 7
-  - 9
 not_validly_adjusted_for_in_g_guess_by_parents_of_t:
   - 2
   - 8
 not_validly_adjusted_for_in_g_guess_by_oset_for_t_onto_y:
   - 2
-  - 3
   - 7
   - 8
-  - 9
 not_validly_adjusted_for_in_g_guess_by_empty_set:
   - 1
   - 2

--- a/gadjid/src/snapshots/gadjid__test__small-DAG13-vs-DAG14.snap
+++ b/gadjid/src/snapshots/gadjid__test__small-DAG13-vs-DAG14.snap
@@ -39,7 +39,6 @@ proper_ancestors_of_y_in_g_guess_wrt_t:
   - 9
 oset_for_t_onto_y_in_g_guess:
   - 0
-  - 3
   - 4
   - 9
 not_validly_adjusted_for_in_g_guess_by_parents_of_t:
@@ -47,7 +46,6 @@ not_validly_adjusted_for_in_g_guess_by_parents_of_t:
   - 9
 not_validly_adjusted_for_in_g_guess_by_oset_for_t_onto_y:
   - 0
-  - 3
   - 4
   - 7
   - 9

--- a/gadjid/src/snapshots/gadjid__test__small-DAG16-vs-DAG17.snap
+++ b/gadjid/src/snapshots/gadjid__test__small-DAG16-vs-DAG17.snap
@@ -45,8 +45,7 @@ proper_ancestors_of_y_in_g_guess_wrt_t:
   - 2
   - 8
   - 9
-oset_for_t_onto_y_in_g_guess:
-  - 3
+oset_for_t_onto_y_in_g_guess: []
 not_validly_adjusted_for_in_g_guess_by_parents_of_t:
   - 0
   - 1
@@ -60,7 +59,6 @@ not_validly_adjusted_for_in_g_guess_by_parents_of_t:
 not_validly_adjusted_for_in_g_guess_by_oset_for_t_onto_y:
   - 1
   - 2
-  - 3
   - 8
   - 9
 not_validly_adjusted_for_in_g_guess_by_empty_set:

--- a/gadjid/src/snapshots/gadjid__test__small-DAG18-vs-DAG19.snap
+++ b/gadjid/src/snapshots/gadjid__test__small-DAG18-vs-DAG19.snap
@@ -39,8 +39,7 @@ possible_descendants_of_t_in_g_guess:
 not_amenable_in_g_guess_wrt_t: []
 proper_ancestors_of_y_in_g_guess_wrt_t:
   - 5
-oset_for_t_onto_y_in_g_guess:
-  - 7
+oset_for_t_onto_y_in_g_guess: []
 not_validly_adjusted_for_in_g_guess_by_parents_of_t:
   - 1
   - 2
@@ -48,7 +47,6 @@ not_validly_adjusted_for_in_g_guess_by_parents_of_t:
   - 6
 not_validly_adjusted_for_in_g_guess_by_oset_for_t_onto_y:
   - 2
-  - 7
   - 9
 not_validly_adjusted_for_in_g_guess_by_empty_set:
   - 2


### PR DESCRIPTION
correct snapshots to use oset calculation from oset-aid (which correctly removes descendants of t (which includes t))