### PR TITLE
Custom node pairs

### DIFF
--- a/gadjid/src/graph_operations/mod.rs
+++ b/gadjid/src/graph_operations/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod ruletables;
 pub use ancestor_aid::ancestor_aid;
 pub use oset_aid::oset_aid;
 pub use parent_aid::parent_aid;
+pub use parent_aid::parent_aid_selective_pairs;
 pub use shd::shd;
 pub use sid::sid;
 

--- a/gadjid/src/graph_operations/parent_aid.rs
+++ b/gadjid/src/graph_operations/parent_aid.rs
@@ -86,7 +86,7 @@ pub fn parent_aid(truth: &PDAG, guess: &PDAG) -> (f64, usize) {
     )
 }
 
-pub fn parent_aid_custom(truth: &PDAG, guess: &PDAG, pairs : Vec<(usize, usize)>) -> (f64, usize) {
+pub fn parent_aid_selective_pairs(truth: &PDAG, guess: &PDAG, pairs : Vec<(usize, usize)>) -> (f64, usize) {
     assert!(
         guess.n_nodes == truth.n_nodes,
         "both graphs must contain the same number of nodes"
@@ -96,7 +96,9 @@ pub fn parent_aid_custom(truth: &PDAG, guess: &PDAG, pairs : Vec<(usize, usize)>
     let mut groups : FxHashMap<usize, Vec<usize>> = FxHashMap::default();
     for (treatment, effect) in pairs {
         let group = groups.entry(treatment).or_insert(Vec::new());
-        group.push(effect);
+        if !group.contains(&effect) {
+            group.push(effect);
+        }
     }
 
     let verifier_mistakes_found = groups
@@ -181,7 +183,7 @@ mod test {
                 let dag1 = PDAG::random_dag(1.0, n, &mut rng);
                 let dag2 = PDAG::random_dag(1.0, n, &mut rng);
                 let (normal, _) = parent_aid(&dag1, &dag2);
-                let (custom, _) = super::parent_aid_custom(&dag1, &dag2, non_diag_pairs.clone());
+                let (custom, _) = super::parent_aid_selective_pairs(&dag1, &dag2, non_diag_pairs.clone());
                 assert_eq!(normal, custom);
             }
         }

--- a/gadjid_python/src/lib.rs
+++ b/gadjid_python/src/lib.rs
@@ -11,6 +11,7 @@ use pyo3::prelude::*;
 use ::gadjid::graph_operations::ancestor_aid as rust_ancestor_aid;
 use ::gadjid::graph_operations::oset_aid as rust_oset_aid;
 use ::gadjid::graph_operations::parent_aid as rust_parent_aid;
+use ::gadjid::graph_operations::parent_aid_selective_pairs as rust_parent_aid_selective_pairs;
 use ::gadjid::graph_operations::shd as rust_shd;
 use ::gadjid::graph_operations::sid as rust_sid;
 use ::gadjid::EdgelistIterator;
@@ -77,6 +78,7 @@ fn gadjid(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(crate::ancestor_aid, m)?)?;
     m.add_function(wrap_pyfunction!(crate::oset_aid, m)?)?;
     m.add_function(wrap_pyfunction!(crate::parent_aid, m)?)?;
+    m.add_function(wrap_pyfunction!(crate::parent_aid_selective_pairs, m)?)?;
     m.add_function(wrap_pyfunction!(crate::shd, m)?)?;
     m.add_function(wrap_pyfunction!(crate::sid, m)?)?;
     Ok(())
@@ -127,6 +129,19 @@ pub fn parent_aid(g_true: &PyAny, g_guess: &PyAny, edge_direction: &str) -> PyRe
     let graph_truth = graph_from_pyobject(g_true, row_to_col)?;
     let graph_guess = graph_from_pyobject(g_guess, row_to_col)?;
     let (normalized_distance, n_errors) = rust_parent_aid(&graph_truth, &graph_guess);
+    Ok((normalized_distance, n_errors))
+}
+
+/// Parent Adjustment Identification Distance between two DAG / CPDAG adjacency matrices (sparse or dense)
+/// Will additionally take two lists of treatments and effects, and grade only the pairs of nodes 
+/// generated from the cartesian product of these two lists.
+#[pyfunction]
+pub fn parent_aid_selective_pairs(g_true: &PyAny, g_guess: &PyAny, treatments : Vec<usize>, effects : Vec<usize>, edge_direction: &str) -> PyResult<(f64, usize)> {
+    let row_to_col = edge_direction_is_row_to_col(edge_direction)?;
+    let graph_truth = graph_from_pyobject(g_true, row_to_col)?;
+    let graph_guess = graph_from_pyobject(g_guess, row_to_col)?;
+    let cartesian_prod = treatments.iter().flat_map(|t| effects.iter().map(move |e| (*t, *e))).collect();
+    let (normalized_distance, n_errors) = rust_parent_aid_selective_pairs(&graph_truth, &graph_guess, cartesian_prod);
     Ok((normalized_distance, n_errors))
 }
 

--- a/gadjid_python/src/lib.rs
+++ b/gadjid_python/src/lib.rs
@@ -133,15 +133,25 @@ pub fn parent_aid(g_true: &PyAny, g_guess: &PyAny, edge_direction: &str) -> PyRe
 }
 
 /// Parent Adjustment Identification Distance between two DAG / CPDAG adjacency matrices (sparse or dense)
-/// Will additionally take two lists of treatments and effects, and grade only the pairs of nodes 
+/// Will additionally take two lists of treatments and effects, and grade only the pairs of nodes
 /// generated from the cartesian product of these two lists.
 #[pyfunction]
-pub fn parent_aid_selective_pairs(g_true: &PyAny, g_guess: &PyAny, treatments : Vec<usize>, effects : Vec<usize>, edge_direction: &str) -> PyResult<(f64, usize)> {
+pub fn parent_aid_selective_pairs(
+    g_true: &PyAny,
+    g_guess: &PyAny,
+    treatments: Vec<usize>,
+    effects: Vec<usize>,
+    edge_direction: &str,
+) -> PyResult<(f64, usize)> {
     let row_to_col = edge_direction_is_row_to_col(edge_direction)?;
     let graph_truth = graph_from_pyobject(g_true, row_to_col)?;
     let graph_guess = graph_from_pyobject(g_guess, row_to_col)?;
-    let cartesian_prod = treatments.iter().flat_map(|t| effects.iter().map(move |e| (*t, *e))).collect();
-    let (normalized_distance, n_errors) = rust_parent_aid_selective_pairs(&graph_truth, &graph_guess, cartesian_prod);
+    let cartesian_prod = treatments
+        .iter()
+        .flat_map(|t| effects.iter().map(move |e| (*t, *e)))
+        .collect();
+    let (normalized_distance, n_errors) =
+        rust_parent_aid_selective_pairs(&graph_truth, &graph_guess, cartesian_prod);
     Ok((normalized_distance, n_errors))
 }
 

--- a/gadjid_python/tests/test_DAG_loading_for_all_formats.py
+++ b/gadjid_python/tests/test_DAG_loading_for_all_formats.py
@@ -1,23 +1,8 @@
 # SPDX-License-Identifier: MPL-2.0
 import numpy as np
 import scipy
-
 import gadjid
-
-
-def make_dag(size, density, seed) -> np.ndarray:
-    np.random.seed(seed)
-    dense: np.ndarray = np.random.binomial(
-        1, density, size=(size, size)
-    ).astype(np.int8)
-    # fill lower triangle+diagonal with zeros
-    dense = np.triu(dense, 1)
-    perm = np.random.permutation(size)
-    return dense[perm, :][:, perm]
-
-
-ROW_TO_COL = "from row to column"
-COL_TO_ROW = "from column to row"
+from utils import FROM_ROW_TO_COL, FROM_COL_TO_ROW, make_dag
 
 
 def test_edge_direction_argument():
@@ -26,28 +11,28 @@ def test_edge_direction_argument():
         size = 10
 
         # make 2 random dags:
-        truth_dag = make_dag(size, 0.5, exp)
-        guess_dag = make_dag(size, 0.5, exp + exps)
+        truth_dag = make_dag(size, density=0.5, seed=exp)
+        guess_dag = make_dag(size, density=0.5, seed=exp + exps)
 
         # for all functions that take an edge_direction argument, check that
         # the result is the same for both edge directions
         assert gadjid.sid(
-            truth_dag, guess_dag, edge_direction=ROW_TO_COL
-        ) == gadjid.sid(truth_dag.T, guess_dag.T, edge_direction=COL_TO_ROW)
+            truth_dag, guess_dag, edge_direction=FROM_ROW_TO_COL
+        ) == gadjid.sid(truth_dag.T, guess_dag.T, edge_direction=FROM_COL_TO_ROW)
         assert gadjid.parent_aid(
-            truth_dag, guess_dag, edge_direction=ROW_TO_COL
+            truth_dag, guess_dag, edge_direction=FROM_ROW_TO_COL
         ) == gadjid.parent_aid(
-            truth_dag.T, guess_dag.T, edge_direction=COL_TO_ROW
+            truth_dag.T, guess_dag.T, edge_direction=FROM_COL_TO_ROW
         )
         assert gadjid.ancestor_aid(
-            truth_dag, guess_dag, edge_direction=ROW_TO_COL
+            truth_dag, guess_dag, edge_direction=FROM_ROW_TO_COL
         ) == gadjid.ancestor_aid(
-            truth_dag.T, guess_dag.T, edge_direction=COL_TO_ROW
+            truth_dag.T, guess_dag.T, edge_direction=FROM_COL_TO_ROW
         )
         assert gadjid.oset_aid(
-            truth_dag, guess_dag, edge_direction=ROW_TO_COL
+            truth_dag, guess_dag, edge_direction=FROM_ROW_TO_COL
         ) == gadjid.oset_aid(
-            truth_dag.T, guess_dag.T, edge_direction=COL_TO_ROW
+            truth_dag.T, guess_dag.T, edge_direction=FROM_COL_TO_ROW
         )
 
 

--- a/gadjid_python/tests/test_DAG_loading_for_all_formats.py
+++ b/gadjid_python/tests/test_DAG_loading_for_all_formats.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: MPL-2.0
 import numpy as np
 import scipy
+from utils import FROM_COL_TO_ROW, FROM_ROW_TO_COL, make_dag
+
 import gadjid
-from utils import FROM_ROW_TO_COL, FROM_COL_TO_ROW, make_dag
 
 
 def test_edge_direction_argument():
@@ -18,7 +19,9 @@ def test_edge_direction_argument():
         # the result is the same for both edge directions
         assert gadjid.sid(
             truth_dag, guess_dag, edge_direction=FROM_ROW_TO_COL
-        ) == gadjid.sid(truth_dag.T, guess_dag.T, edge_direction=FROM_COL_TO_ROW)
+        ) == gadjid.sid(
+            truth_dag.T, guess_dag.T, edge_direction=FROM_COL_TO_ROW
+        )
         assert gadjid.parent_aid(
             truth_dag, guess_dag, edge_direction=FROM_ROW_TO_COL
         ) == gadjid.parent_aid(

--- a/gadjid_python/tests/test_distance_with_custom_pairs_argument.py
+++ b/gadjid_python/tests/test_distance_with_custom_pairs_argument.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: MPL-2.0
+import gadjid
+from utils import FROM_ROW_TO_COL, FROM_COL_TO_ROW, make_dag
+
+
+def compare_selective_pairs_to_all_pairs():
+    exps = 10
+    for exp in range(exps):
+        size = 10
+
+        # make 2 random dags:
+        truth_dag = make_dag(size, density=0.5, seed=exp)
+        guess_dag = make_dag(size, density=0.5, seed=exp + exps)
+
+        assert gadjid.parent_aid(
+            truth_dag, guess_dag, edge_direction=FROM_ROW_TO_COL
+        ) == gadjid.parent_aid_selective_pairs(
+            truth_dag.T, guess_dag.T, treatments=list(range(size)), effects=list(range(size)), edge_direction=FROM_COL_TO_ROW
+        )
+
+def one_empty_leads_to_zero_distance():
+    exps = 10
+    for exp in range(exps):
+        size = 10
+        # make 2 random dags:
+        truth_dag = make_dag(size, density=0.5, seed=exp)
+        guess_dag = make_dag(size, density=0.5, seed=exp + exps)
+
+        assert gadjid.parent_aid_selective_pairs(
+            truth_dag.T, guess_dag.T, treatments=[], effects=list(range(size)), edge_direction=FROM_COL_TO_ROW
+        ) == (0.0, 0)
+        
+        assert gadjid.parent_aid_selective_pairs(
+            truth_dag.T, guess_dag.T, treatments=list(range(size)), effects = [], edge_direction=FROM_COL_TO_ROW
+        ) == (0.0, 0)
+
+if __name__ == "__main__":
+    compare_selective_pairs_to_all_pairs()
+    one_empty_leads_to_zero_distance()
+    print("all tests passed")

--- a/gadjid_python/tests/test_distance_with_custom_pairs_argument.py
+++ b/gadjid_python/tests/test_distance_with_custom_pairs_argument.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
+from utils import FROM_COL_TO_ROW, FROM_ROW_TO_COL, make_dag
+
 import gadjid
-from utils import FROM_ROW_TO_COL, FROM_COL_TO_ROW, make_dag
 
 
 def compare_selective_pairs_to_all_pairs():
@@ -15,8 +16,13 @@ def compare_selective_pairs_to_all_pairs():
         assert gadjid.parent_aid(
             truth_dag, guess_dag, edge_direction=FROM_ROW_TO_COL
         ) == gadjid.parent_aid_selective_pairs(
-            truth_dag.T, guess_dag.T, treatments=list(range(size)), effects=list(range(size)), edge_direction=FROM_COL_TO_ROW
+            truth_dag.T,
+            guess_dag.T,
+            treatments=list(range(size)),
+            effects=list(range(size)),
+            edge_direction=FROM_COL_TO_ROW,
         )
+
 
 def one_empty_leads_to_zero_distance():
     exps = 10
@@ -27,12 +33,21 @@ def one_empty_leads_to_zero_distance():
         guess_dag = make_dag(size, density=0.5, seed=exp + exps)
 
         assert gadjid.parent_aid_selective_pairs(
-            truth_dag.T, guess_dag.T, treatments=[], effects=list(range(size)), edge_direction=FROM_COL_TO_ROW
+            truth_dag.T,
+            guess_dag.T,
+            treatments=[],
+            effects=list(range(size)),
+            edge_direction=FROM_COL_TO_ROW,
         ) == (0.0, 0)
-        
+
         assert gadjid.parent_aid_selective_pairs(
-            truth_dag.T, guess_dag.T, treatments=list(range(size)), effects = [], edge_direction=FROM_COL_TO_ROW
+            truth_dag.T,
+            guess_dag.T,
+            treatments=list(range(size)),
+            effects=[],
+            edge_direction=FROM_COL_TO_ROW,
         ) == (0.0, 0)
+
 
 if __name__ == "__main__":
     compare_selective_pairs_to_all_pairs()

--- a/gadjid_python/tests/test_parent_AID_against_R_SID.py
+++ b/gadjid_python/tests/test_parent_AID_against_R_SID.py
@@ -2,9 +2,9 @@
 from pathlib import Path
 
 import numpy as np
+from utils import FROM_ROW_TO_COL
 
 from gadjid import parent_aid
-from utils import FROM_ROW_TO_COL, FROM_COL_TO_ROW
 
 
 TESTGRAPHS_DIR = Path(__file__).parent.parent.parent / "testgraphs"
@@ -39,6 +39,7 @@ def test_parent_AID_against_R_SID():
             f"failed for sid({true_name}, {guess_name}):"
             f" {sid[1]} vs {int(rsid)}"
         )
+
 
 if __name__ == "__main__":
     test_parent_AID_against_R_SID()

--- a/gadjid_python/tests/test_parent_AID_against_R_SID.py
+++ b/gadjid_python/tests/test_parent_AID_against_R_SID.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import numpy as np
 
 from gadjid import parent_aid
+from utils import FROM_ROW_TO_COL, FROM_COL_TO_ROW
 
 
 TESTGRAPHS_DIR = Path(__file__).parent.parent.parent / "testgraphs"
@@ -33,8 +34,12 @@ def test_parent_AID_against_R_SID():
         guess_name = int(guess_name)
         Gtrue = load_trlpt(true_name)
         Gguess = load_trlpt(guess_name)
-        sid = parent_aid(Gtrue, Gguess, edge_direction="from row to column")
+        sid = parent_aid(Gtrue, Gguess, edge_direction=FROM_ROW_TO_COL)
         assert sid[1] == int(rsid), (
             f"failed for sid({true_name}, {guess_name}):"
             f" {sid[1]} vs {int(rsid)}"
         )
+
+if __name__ == "__main__":
+    test_parent_AID_against_R_SID()
+    print("all tests passed")

--- a/gadjid_python/tests/utils.py
+++ b/gadjid_python/tests/utils.py
@@ -1,7 +1,9 @@
 import numpy as np
 
+
 FROM_ROW_TO_COL = "from row to column"
 FROM_COL_TO_ROW = "from column to row"
+
 
 def make_dag(size, density, seed) -> np.ndarray:
     np.random.seed(seed)

--- a/gadjid_python/tests/utils.py
+++ b/gadjid_python/tests/utils.py
@@ -1,0 +1,14 @@
+import numpy as np
+
+FROM_ROW_TO_COL = "from row to column"
+FROM_COL_TO_ROW = "from column to row"
+
+def make_dag(size, density, seed) -> np.ndarray:
+    np.random.seed(seed)
+    dense: np.ndarray = np.random.binomial(
+        1, density, size=(size, size)
+    ).astype(np.int8)
+    # fill lower triangle+diagonal with zeros
+    dense = np.triu(dense, 1)
+    perm = np.random.permutation(size)
+    return dense[perm, :][:, perm]


### PR DESCRIPTION
As described in the article and requested in recent issue #7, add variants of all the distances that take parameters to define what pairs of (T,Y) to check between the two graphs.

This PR introduces 3 new functions in the python API:

- `ancestor_aid_selective_pairs`
- `parent_aid_selective_pairs`
- `oset_aid_selective_pairs`

*(naming TBD)*

They take the same arguments as their shorter-named relatives, plus two additional ones:

```
parent_aid_selective_pairs (
  g_true:         adjacency matrix
  g_guess:        adjacency matrix,
  treatments:     list of nodes, *new*
  effects:        list of nodes, *new*
  edge_direction: string,
) -> (float, int)
```

The pairs for which mistakes are counted are taken from 

(T, Y) $\in$ $\\{$`treatments` $\times$ `effects` $\\}$


We then redefine `parent_aid` as a special case of `parent_aid_selective_pairs` (new addition), where `parent_aid` will now have the `t_y_pairs_to_grade` argument set to `[all pairs]` by default.

In summary, the python interface can now take two lists of `T` and `Y`, from which the cartesian product will provide the pairs to grade, while in Rust one can supply a fully custom list of pairs, say [(1,2), (2,3)]. 