### PR TITLE
make `rayon` use # of physical CPUs instead of logical CPUs

### DIFF
--- a/gadjid/Cargo.lock
+++ b/gadjid/Cargo.lock
@@ -62,6 +62,7 @@ name = "gadjid"
 version = "0.1.0-a.1"
 dependencies = [
  "insta",
+ "num_cpus",
  "rand",
  "rand_chacha",
  "rayon",
@@ -79,6 +80,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "insta"
@@ -110,6 +117,16 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
 
 [[package]]
 name = "ppv-lite86"

--- a/gadjid/Cargo.toml
+++ b/gadjid/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/CausalDisco/gadjid"
 publish = false
 
 [dependencies]
+num_cpus = "1.16.0"
 rand = "0.8"
 rand_chacha = "0.3"
 rayon = "1.8"

--- a/gadjid/src/graph_operations/ancestor_aid.rs
+++ b/gadjid/src/graph_operations/ancestor_aid.rs
@@ -24,6 +24,8 @@ pub fn ancestor_aid(truth: &PDAG, guess: &PDAG) -> (f64, usize) {
     );
     assert!(guess.n_nodes >= 2, "graph must contain at least 2 nodes");
 
+    let _ = rayon::ThreadPoolBuilder::new().num_threads(num_cpus::get_physical()).build_global();
+
     let verifier_mistakes_found = (0..guess.n_nodes)
         .into_par_iter()
         .map(|treatment| {

--- a/gadjid/src/graph_operations/ancestor_aid.rs
+++ b/gadjid/src/graph_operations/ancestor_aid.rs
@@ -24,7 +24,9 @@ pub fn ancestor_aid(truth: &PDAG, guess: &PDAG) -> (f64, usize) {
     );
     assert!(guess.n_nodes >= 2, "graph must contain at least 2 nodes");
 
-    let _ = rayon::ThreadPoolBuilder::new().num_threads(num_cpus::get_physical()).build_global();
+    let _ = rayon::ThreadPoolBuilder::new()
+        .num_threads(num_cpus::get_physical())
+        .build_global();
 
     let verifier_mistakes_found = (0..guess.n_nodes)
         .into_par_iter()

--- a/gadjid/src/graph_operations/oset_aid.rs
+++ b/gadjid/src/graph_operations/oset_aid.rs
@@ -38,6 +38,8 @@ pub fn oset_aid(truth: &PDAG, guess: &PDAG) -> (f64, usize) {
     );
     assert!(guess.n_nodes >= 2, "graph must contain at least 2 nodes");
 
+    let _ = rayon::ThreadPoolBuilder::new().num_threads(num_cpus::get_physical()).build_global();
+
     let verifier_mistakes_found = (0..guess.n_nodes)
         .into_par_iter()
         .map(|treatment| {

--- a/gadjid/src/graph_operations/oset_aid.rs
+++ b/gadjid/src/graph_operations/oset_aid.rs
@@ -38,7 +38,9 @@ pub fn oset_aid(truth: &PDAG, guess: &PDAG) -> (f64, usize) {
     );
     assert!(guess.n_nodes >= 2, "graph must contain at least 2 nodes");
 
-    let _ = rayon::ThreadPoolBuilder::new().num_threads(num_cpus::get_physical()).build_global();
+    let _ = rayon::ThreadPoolBuilder::new()
+        .num_threads(num_cpus::get_physical())
+        .build_global();
 
     let verifier_mistakes_found = (0..guess.n_nodes)
         .into_par_iter()

--- a/gadjid/src/graph_operations/parent_aid.rs
+++ b/gadjid/src/graph_operations/parent_aid.rs
@@ -3,7 +3,6 @@
 
 use rayon::prelude::*;
 use rustc_hash::FxHashSet;
-
 use crate::{
     graph_operations::{get_nam, get_pd_nam_nva},
     PDAG,
@@ -21,6 +20,8 @@ pub fn parent_aid(truth: &PDAG, guess: &PDAG) -> (f64, usize) {
         "both graphs must contain the same number of nodes"
     );
     assert!(guess.n_nodes >= 2, "graph must contain at least 2 nodes");
+
+    let _ = rayon::ThreadPoolBuilder::new().num_threads(num_cpus::get_physical()).build_global();
 
     let verifier_mistakes_found = (0..guess.n_nodes)
         .into_par_iter()

--- a/gadjid/src/graph_operations/parent_aid.rs
+++ b/gadjid/src/graph_operations/parent_aid.rs
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 //! Implements the Parent Adjustment Intervention Distance (Parent-AID) algorithm
 
-use rayon::prelude::*;
-use rustc_hash::FxHashSet;
 use crate::{
     graph_operations::{get_nam, get_pd_nam_nva},
     PDAG,
 };
+use rayon::prelude::*;
+use rustc_hash::FxHashSet;
 
 /// Computes the parent adjustment intervention distance
 /// between an estimated `guess` DAG or CPDAG and the true `truth` DAG or CPDAG
@@ -21,7 +21,9 @@ pub fn parent_aid(truth: &PDAG, guess: &PDAG) -> (f64, usize) {
     );
     assert!(guess.n_nodes >= 2, "graph must contain at least 2 nodes");
 
-    let _ = rayon::ThreadPoolBuilder::new().num_threads(num_cpus::get_physical()).build_global();
+    let _ = rayon::ThreadPoolBuilder::new()
+        .num_threads(num_cpus::get_physical())
+        .build_global();
 
     let verifier_mistakes_found = (0..guess.n_nodes)
         .into_par_iter()

--- a/gadjid_python/Cargo.lock
+++ b/gadjid_python/Cargo.lock
@@ -61,6 +61,7 @@ checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 name = "gadjid"
 version = "0.1.0-a.1"
 dependencies = [
+ "num_cpus",
  "rand",
  "rand_chacha",
  "rayon",
@@ -93,6 +94,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "indoc"
@@ -173,6 +180,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]


### PR DESCRIPTION
Small change to the codebase using the `num_cpus` crate.